### PR TITLE
build: Fix xxhash x86 dispatch

### DIFF
--- a/vendor/xxHash/CMakeLists.txt
+++ b/vendor/xxHash/CMakeLists.txt
@@ -6,7 +6,8 @@ add_library(xxHash
 
 ## Add x86 dispatch if compiling for x86_64
 CMAKE_HOST_SYSTEM_INFORMATION(RESULT PLATFORM QUERY OS_PLATFORM)
-if (DEFINED PLATFORM)
+string(TOLOWER "${PLATFORM}" PLATFORM)
+if (PLATFORM MATCHES "^(amd64|x86_64)$")
     set(XXHSUM_DISPATCH ON)
 	target_sources(xxHash PRIVATE
 		xxHash/xxh_x86dispatch.c


### PR DESCRIPTION
When compiling for a non-x86 platform, the x86-dispatch should not be included by explicitly checking the value of the `OS_PLATFORM` query-result.