### PR TITLE
fix(rtc): Initialize `RTC::m_offset` to zero

### DIFF
--- a/libs/ymir-core/src/ymir/hw/smpc/rtc.cpp
+++ b/libs/ymir-core/src/ymir/hw/smpc/rtc.cpp
@@ -31,6 +31,7 @@ RTC::RTC(core::Configuration::RTC &config)
 
     config.mode.Observe(m_mode);
 
+    m_offset = 0;
     m_timestamp = 0;
 
     Reset(true);


### PR DESCRIPTION
`RTC::m_offset` is uninitialized, which causes functions like `util::datetime::host` to be given undefined-data and further-creates undefined `DateTime`-values which causes even later functions like `SystemStateWindow::DrawRealTimeClock` to crash at times like when opening `System > System State` without an IPL loaded.

![image](https://github.com/user-attachments/assets/ec40fae8-ee1c-4895-8b13-f8adc9ddefb9)
