### PR TITLE
fix(vdp): Ensure `VDP1BeginFrame`-handler breaks out of case-switch

### DIFF
--- a/libs/ymir-core/src/ymir/hw/vdp/vdp.cpp
+++ b/libs/ymir-core/src/ymir/hw/vdp/vdp.cpp
@@ -1348,8 +1348,8 @@ void VDP::VDPRenderThread() {
                     for (int i = 0; i < 100000 && m_VDP1RenderContext.rendering; i++) {
                         VDP1ProcessCommand();
                     }
-                    break;
                 }
+                break;
             /*case EvtType::VDP1ProcessCommands:
                 if (m_threadedVDPRendering) {
                     for (uint64 i = 0; i < event.processCommands.steps; i++) {


### PR DESCRIPTION
This `break;` should be outside of the `if`-statement, otherwise `VDP2DrawLine` will be called in the case that the threaded VDP renderer is enabled.