### PR TITLE
build: Implement cross-compilation support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,13 +21,29 @@ option(Ymir_ENABLE_DEVLOG "Enable development logs" ON)
 option(Ymir_ENABLE_IMGUI_DEMO "Enable ImGui demo window" ON)
 message(STATUS "Ymir: Devlog ${Ymir_ENABLE_DEVLOG}")
 
-## Performance options
-option(Ymir_AVX2 "Enable AVX2 instruction set for Ymir" OFF)
-if (Ymir_AVX2)
-    message(STATUS "Ymir: Using AVX2 instruction set")
-else ()
-    message(STATUS "Ymir: Using SSE2 instruction set")
+# Detect target architectures
+# ARCHITECTURES may have multiple variables in the case of a multi-arch build
+# such as a universal binary on MacOS
+include(cmake/DetectArchitecture.cmake)
+if (NOT DEFINED ARCHITECTURES)
+    message(FATAL_ERROR "Unsupported architecture")
 endif ()
+message(STATUS "Ymir: Architecture(s) ${ARCHITECTURES}")
+
+## Performance options
+if ("x86_64" IN_LIST ARCHITECTURES)
+	option(Ymir_AVX2 "Enable AVX2 instruction set for Ymir" OFF)
+	if (Ymir_AVX2)
+		message(STATUS "Ymir: Using AVX2 instruction set")
+	else ()
+		message(STATUS "Ymir: Using SSE2 instruction set")
+	endif ()
+endif ()
+
+if ("arm64" IN_LIST ARCHITECTURES)
+	message(STATUS "Ymir: Using NEON instruction set")
+endif ()
+
 
 ## C++ language configuration boilerplate
 if (NOT DEFINED CMAKE_CXX_VISIBILITY_PRESET AND

--- a/cmake/DetectArchitecture.cmake
+++ b/cmake/DetectArchitecture.cmake
@@ -1,0 +1,40 @@
+include(CheckSymbolExists)
+
+# Universal Binaries on MacOS will already list all the target architectures
+if (CMAKE_OSX_ARCHITECTURES)
+    set(ARCHITECTURES "${CMAKE_OSX_ARCHITECTURES}")
+    return()
+endif ()
+
+# Test if the target C/C++ compiler has the symbol defined
+# Allows for architecture to be defined by the compiler rather than the
+# just the architecture of the host-machine to allow for cross-compilation
+function(detect_arch_symbol symbol arch)
+    if (NOT DEFINED ARCHITECTURES)
+        set(CMAKE_REQUIRED_QUIET YES)
+        check_symbol_exists("${symbol}" "" symbol_found_${arch})
+        unset(CMAKE_REQUIRED_QUIET)
+
+        if (symbol_found_${arch})
+            set(ARCHITECTURES "${arch}" PARENT_SCOPE)
+        endif ()
+
+        unset(symbol_found_${arch} CACHE)
+    endif ()
+endfunction ()
+
+# arm64
+detect_arch_symbol("__aarch64__" arm64) # Clang/GCC
+detect_arch_symbol("__ARM_ARCH_ISA_A64" arm64) # Clang/GCC
+detect_arch_symbol("__arm64__ " arm64) # Clang/GCC
+detect_arch_symbol("__ARM64__" arm64) # Clang/GCC
+detect_arch_symbol("__arm64" arm64) # Clang/GCC
+detect_arch_symbol("__ARM_ARCH" arm64) # MSVC
+detect_arch_symbol("_M_ARM64" arm64) # MSVC
+
+# x86_64
+detect_arch_symbol("__amd64" x86_64) # Clang/GCC
+detect_arch_symbol("__x86_64__" x86_64) # Clang/GCC
+detect_arch_symbol("__x86_64" x86_64) # Clang/GCC
+detect_arch_symbol("_M_AMD64" x86_64) # MSVC
+detect_arch_symbol("_M_X64" x86_64) # MSVC

--- a/vendor/xxHash/CMakeLists.txt
+++ b/vendor/xxHash/CMakeLists.txt
@@ -4,10 +4,7 @@ add_library(xxHash
 	xxHash/xxh3.h
 )
 
-## Add x86 dispatch if compiling for x86_64
-CMAKE_HOST_SYSTEM_INFORMATION(RESULT PLATFORM QUERY OS_PLATFORM)
-string(TOLOWER "${PLATFORM}" PLATFORM)
-if (PLATFORM MATCHES "^(amd64|x86_64)$")
+if ("x86_64" IN_LIST ARCHITECTURES)
     set(XXHSUM_DISPATCH ON)
 	target_sources(xxHash PRIVATE
 		xxHash/xxh_x86dispatch.c
@@ -26,12 +23,14 @@ target_include_directories(xxHash
 target_compile_features(xxHash PUBLIC cxx_std_20)
 
 ## Apply performance options
-if (Ymir_AVX2)
-    if (MSVC)
-        target_compile_options(xxHash PUBLIC "/arch:AVX2")
-    else ()
-        target_compile_options(xxHash PUBLIC "-mavx2")
-        target_compile_options(xxHash PUBLIC "-mfma")
-        target_compile_options(xxHash PUBLIC "-mbmi")
-    endif ()
+if ("x86_64" IN_LIST ARCHITECTURES)
+	if (Ymir_AVX2)
+		if (MSVC)
+			target_compile_options(xxHash PUBLIC "/arch:AVX2")
+		else ()
+			target_compile_options(xxHash PUBLIC "-mavx2")
+			target_compile_options(xxHash PUBLIC "-mfma")
+			target_compile_options(xxHash PUBLIC "-mbmi")
+		endif ()
+	endif ()
 endif ()


### PR DESCRIPTION
Rather than using the architecture of the host machine, use the architecture that the compiler is designated for by detecting architecture-specific symbols.

Currently, multi-arch build support for MacOS(Universal-Binary with both arm64+x64 in the same binary) does not work due to the mechanism that xxhash uses. Will work on that later.

This allows an `x64` host to make an `arm64` build and the other way around(Tested on Windows and MacOS).