### PR TITLE
fix(bit_ops): Use optimized byte_swap specializations on Clang/GCC

### DIFF
--- a/libs/ymir-core/include/ymir/util/bit_ops.hpp
+++ b/libs/ymir-core/include/ymir/util/bit_ops.hpp
@@ -7,6 +7,8 @@
 
 #include "inline.hpp"
 
+#include <ymir/core/types.hpp>
+
 #include <array>
 #include <bit>
 #include <climits>
@@ -249,6 +251,23 @@ template <std::unsigned_integral T>
 [[nodiscard]] FORCE_INLINE constexpr T byte_swap(T value) noexcept {
     return detail::byte_swap_impl<T>(value, std::make_index_sequence<sizeof(T)>{});
 }
+
+#if defined(__clang__) || defined(__GNUC__)
+template <>
+[[nodiscard]] FORCE_INLINE constexpr uint64 byte_swap<uint64>(uint64 value) noexcept {
+    return __builtin_bswap64(value);
+}
+
+template <>
+[[nodiscard]] FORCE_INLINE constexpr uint32 byte_swap<uint32>(uint32 value) noexcept {
+    return __builtin_bswap32(value);
+}
+
+template <>
+[[nodiscard]] FORCE_INLINE constexpr uint16 byte_swap<uint16>(uint16 value) noexcept {
+    return __builtin_bswap16(value);
+}
+#endif
 
 /// @brief Swaps the bytes of `value` if `endianness` doesn't match the native endianness.
 ///


### PR DESCRIPTION
Byte-swapping is done at almost every read/write and could be using compiler intrinsics that map directly to optimal assembly rather than emitting explicit debug-code all the time. Should help make debug-build performance a little bit faster.

This allows for more optimal byte-swapping code to be emitted in debug-mode rather than the more explicit debug-mode assembly. This is only implemented for Clang/GCC since MSVC does not have a `constexpr` implementation of their bswap builtins. `std::is_constant_evaluated` is also an actual function-call on MSVC in debug mode, which defeats the purpose of trying to remove additional overhead from endian-swapping.

Before:
![Code_uKRcEMtiFb](https://github.com/user-attachments/assets/a44d3987-c297-4da6-8eaa-108f898831e0)
![Code_SXFOznRgc6](https://github.com/user-attachments/assets/7b986460-bcca-4515-a4aa-91b72473add5)

After:
![Code_rlqGHT3qfe](https://github.com/user-attachments/assets/f3ca22dd-c66c-4c8b-9dab-2f3ccf251eca)
![Code_IXMOkN7HPz](https://github.com/user-attachments/assets/6dc32ea5-180a-4fc2-aa68-78ac8c844ea4)
