### PR TITLE
fix(bit_ops): Fix `extract/deposit` bit-mask generation

### DIFF
--- a/libs/ymir-core/include/ymir/util/bit_ops.hpp
+++ b/libs/ymir-core/include/ymir/util/bit_ops.hpp
@@ -94,7 +94,7 @@ template <std::size_t start, std::size_t end = start, std::integral T>
     using UT = std::make_unsigned_t<T>;
 
     constexpr std::size_t length = end - start;
-    constexpr UT mask = static_cast<UT>(~(~0 << length << 1));
+    constexpr UT mask = static_cast<UT>(~(~UT{0} << length << 1));
     return (value >> start) & mask;
 }
 
@@ -135,7 +135,7 @@ template <std::size_t start, std::size_t end = start, std::integral T, std::inte
     using UT = std::make_unsigned_t<T>;
 
     constexpr std::size_t length = end - start;
-    constexpr UT mask = static_cast<UT>(~(~0 << length << 1));
+    constexpr UT mask = static_cast<UT>(~(~UT{0} << length << 1));
     base &= ~(mask << start);
     base |= (value & mask) << start;
     return base;


### PR DESCRIPTION
A very small fix I ran into while experimenting with some stuff.

The `~0` terms here is implicitly a 32-bit integer value(`0xFFFFFFFF`), causing cases where bits in the mask larger than 32-bits to fail such as `extract<16,63>`.

The zero just needs to be casted to `UT` to properly handle 64-bit values.