### PR TITLE
feat(data_ops): Remove `{Read,Write}{BE,LE}` explicit call to `memcpy`

### DIFF
--- a/libs/ymir-core/include/ymir/util/data_ops.hpp
+++ b/libs/ymir-core/include/ymir/util/data_ops.hpp
@@ -32,8 +32,7 @@ template <uint32 start, uint32 end>
 /// @return the value at `data` reinterpreted as a big-endian integer of type `T`
 template <std::integral T>
 [[nodiscard]] FORCE_INLINE T ReadBE(const void *data) {
-    T value = 0;
-    std::memcpy(&value, data, sizeof(T));
+    T value = *static_cast<const T *>(data);
     if constexpr (std::endian::native == std::endian::little) {
         value = bit::byte_swap(value);
     }
@@ -49,7 +48,7 @@ FORCE_INLINE void WriteBE(void *data, T value) {
     if constexpr (std::endian::native == std::endian::little) {
         value = bit::byte_swap(value);
     }
-    std::memcpy(data, &value, sizeof(T));
+    *static_cast<T *>(data) = value;
 }
 
 /// @brief Reads a little-endian integer from the given pointer.
@@ -58,8 +57,7 @@ FORCE_INLINE void WriteBE(void *data, T value) {
 /// @return the value at `data` reinterpreted as a little-endian integer of type `T`
 template <std::integral T>
 [[nodiscard]] FORCE_INLINE T ReadLE(const void *data) {
-    T value = 0;
-    std::memcpy(&value, data, sizeof(T));
+    T value = *static_cast<const T *>(data);
     if constexpr (std::endian::native == std::endian::big) {
         value = bit::byte_swap(value);
     }
@@ -75,7 +73,7 @@ FORCE_INLINE void WriteLE(void *data, T value) {
     if constexpr (std::endian::native == std::endian::big) {
         value = bit::byte_swap(value);
     }
-    std::memcpy(data, &value, sizeof(T));
+    *static_cast<T *>(data) = value;
 }
 
 /// @brief Reads a native-endian integer from the given pointer.
@@ -84,8 +82,7 @@ FORCE_INLINE void WriteLE(void *data, T value) {
 /// @return the value at `data` reinterpreted as a native-endian integer of type `T`
 template <std::integral T>
 [[nodiscard]] FORCE_INLINE T ReadNE(const void *data) {
-    T value = 0;
-    std::memcpy(&value, data, sizeof(T));
+    const T value = *static_cast<const T *>(data);
     return value;
 }
 
@@ -95,7 +92,7 @@ template <std::integral T>
 /// @param[in] value the value to write at `data` in native-endian order
 template <std::integral T>
 FORCE_INLINE void WriteNE(void *data, T value) {
-    std::memcpy(data, &value, sizeof(T));
+    *static_cast<T *>(data) = value;
 }
 
 /// @brief Converts a decimal string into an integer.


### PR DESCRIPTION
These calls to `memcpy` are _actual_ calls to `memcpy` in debug-mode and can be replaced with simpler pointer-arithmetic to remove the overhead of these high-traffic data-ops.

What used to be a `memcpy`-call is now just a simple move-instruction.

`ldrh`/`strh` in the case of the arm64 device I am testing this on. Likely `mov` on x64 and maybe this even lends itself a bit better for the compiler to emit a [movbe](https://www.felixcloutier.com/x86/movbe) instruction.