### PR TITLE
feat(SCU): Implement Instruction bit-field type

### DIFF
--- a/apps/ymir-sdl3/src/app/ui/views/debug/scu_dsp_disassembly_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/scu_dsp_disassembly_view.cpp
@@ -34,7 +34,7 @@ void SCUDSPDisassemblyView::Display() {
         ImGui::TableHeadersRow();
 
         for (uint32 pc = 0; pc <= 0xFF; pc++) {
-            const uint32 opcode = m_dsp.programRAM[pc];
+            const uint32 opcode = m_dsp.programRAM[pc].u32;
             const auto disasm = scu::Disassemble(opcode);
 
             ImGui::TableNextRow();

--- a/libs/ymir-core/CMakeLists.txt
+++ b/libs/ymir-core/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(ymir-core
     include/ymir/hw/scu/scu_defs.hpp
     include/ymir/hw/scu/scu_dma.hpp
     include/ymir/hw/scu/scu_dsp.hpp
+    include/ymir/hw/scu/scu_dsp_instr.hpp
     include/ymir/hw/scu/scu_dsp_disasm.hpp
     include/ymir/hw/scu/scu_internal_callbacks.hpp
 

--- a/libs/ymir-core/include/ymir/hw/scu/scu_dsp.hpp
+++ b/libs/ymir-core/include/ymir/hw/scu/scu_dsp.hpp
@@ -14,6 +14,8 @@
 
 #include <array>
 
+#include "scu_dsp_instr.hpp"
+
 namespace ymir::scu {
 
 using CBTriggerDSPEnd = util::RequiredCallback<void()>;
@@ -41,7 +43,7 @@ public:
     // Memory accessors
 
     uint32 ReadProgram() {
-        return programRAM[PC];
+        return programRAM[PC].u32;
     }
 
     template <bool poke>
@@ -53,7 +55,7 @@ public:
             }
         }
 
-        programRAM[PC++] = value;
+        programRAM[PC++].u32 = value;
     }
 
     template <bool peek>
@@ -336,7 +338,7 @@ public:
     // -------------------------------------------------------------------------
     // State
 
-    std::array<uint32, 256> programRAM;
+    std::array<DSPInstr, 256> programRAM;
     std::array<std::array<uint32, 64>, 4> dataRAM;
 
     bool programExecuting;
@@ -397,13 +399,13 @@ private:
     // Command interpreters
 
 #define TPL_DEBUG template <bool debug>
-    TPL_DEBUG void Cmd_Operation(uint32 command);
-    TPL_DEBUG void Cmd_LoadImm(uint32 command);
-    TPL_DEBUG void Cmd_Special(uint32 command);
-    TPL_DEBUG void Cmd_Special_DMA(uint32 command);
-    void Cmd_Special_Jump(uint32 command);
-    void Cmd_Special_Loop(uint32 command);
-    void Cmd_Special_End(uint32 command);
+    TPL_DEBUG void Cmd_Operation(DSPInstr instr);
+    TPL_DEBUG void Cmd_LoadImm(DSPInstr instr);
+    TPL_DEBUG void Cmd_Special(DSPInstr instr);
+    TPL_DEBUG void Cmd_Special_DMA(DSPInstr instr);
+    void Cmd_Special_Jump(DSPInstr instr);
+    void Cmd_Special_Loop(DSPInstr instr);
+    void Cmd_Special_End(DSPInstr instr);
 #undef TPL_DEBUG
 };
 

--- a/libs/ymir-core/include/ymir/hw/scu/scu_dsp_instr.hpp
+++ b/libs/ymir-core/include/ymir/hw/scu/scu_dsp_instr.hpp
@@ -42,11 +42,11 @@ union DSPInstr {
         } loadControl;
 
         struct LoadUnconditional {
-            uint32 imm : 25; // 00-24 - Immediate
+            sint32 imm : 25; // 00-24 - Immediate
         } unconditional;
 
         struct LoadConditional {
-            uint32 imm : 19;      // 00-18 - Immediate
+            sint32 imm : 19;      // 00-18 - Immediate
             uint32 condition : 6; // 19-24 - Condition
         } conditional;
     } loadInfo;

--- a/libs/ymir-core/include/ymir/hw/scu/scu_dsp_instr.hpp
+++ b/libs/ymir-core/include/ymir/hw/scu/scu_dsp_instr.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <ymir/core/types.hpp>
+
+namespace ymir::scu {
+
+union DSPInstr {
+    uint32 u32 = 0u;
+
+    constexpr bool operator==(const DSPInstr &rhs) const {
+        return u32 == rhs.u32;
+    }
+    constexpr auto operator<=>(const DSPInstr &rhs) const {
+        return u32 <=> rhs.u32;
+    }
+    struct InstructionControl {
+        uint32 instructionControl : 30; // 00-29 - Instruction control bits
+        uint32 instructionClass : 2;    // 30-31 - Instruction class
+    } instructionInfo;
+
+    // Arithmetic operations
+    struct ALUInstr {
+        sint32 d1BusImm : 8;  // 00-07 - D1-Bus Immediate
+        uint32 d1BusDest : 4; // 08-11 - D1-Bus Destination
+        uint32 d1BusOp : 2;   // 12-13 - D1-Bus Operation
+
+        uint32 yBusSource : 3; // 14-16 - Y-Bus Control
+        uint32 yBusOp : 3;     // 17-19 - Y-Bus Operation
+
+        uint32 xBusSource : 3; // 20-22 - X-Bus Source
+        uint32 xBusOp : 3;     // 23-25 - X-Bus Operation
+
+        uint32 aluOp : 4; // 26-29 - ALU Operation
+    } aluInfo;
+
+    // Load operations
+    union LoadInstr {
+        struct LoadControl {
+            uint32 loadImmControl : 25; // 00-24 - Conditional/Unconditional Control bits
+            uint32 conditionalLoad : 1; // 25 - Conditional/Unconditional load
+            uint32 storageLocation : 4; // 26-29 - Destination
+        } loadControl;
+
+        struct LoadUnconditional {
+            uint32 imm : 25; // 00-24 - Immediate
+        } unconditional;
+
+        struct LoadConditional {
+            uint32 imm : 19;      // 00-18 - Immediate
+            uint32 condition : 6; // 19-24 - Condition
+        } conditional;
+    } loadInfo;
+
+    // Special operations
+    union SpecialInstr {
+        struct SpecialControl {
+            uint32 specialControl : 28; // 00-27 - Special-operation control bits
+            uint32 specialClass : 2;    // 28-29 - Special-operation class
+        } specialControl;
+
+        struct DMAControl {
+            uint32 imm : 8;        // 00-07 - Immediate
+            uint32 address : 3;    // 08-10 - Transfer address
+            uint32 unused : 1;     // 11 - Unused
+            uint32 direction : 1;  // 12 - Transfer direction
+            uint32 sizeSource : 1; // 13 - Transfer size source (Immediate/Memory)
+            uint32 hold : 1;       // 14 - Hold DMA address
+            uint32 stride : 3;     // 15-17 - Address stride
+        } dmaInfo;
+
+        struct JumpControl {
+            uint32 target : 8;    // 00-07 - Jump Target
+            uint32 unused : 11;   // 08-18 - Unused
+            uint32 condition : 6; // 19-24 - Jump Condition
+        } jumpInfo;
+
+        struct LoopControl {
+            uint32 unused : 27; // 0-26 - Unused
+            uint32 repeat : 1;  // 27 - Repeat loop
+        } loopInfo;
+
+        struct EndControl {
+            uint32 unused : 27;   // 0-26 - Unused
+            uint32 interrupt : 1; // 27 - Signal DSP End interrupt
+        } endInfo;
+
+    } specialInfo;
+};
+
+static_assert(sizeof(DSPInstr) == sizeof(uint32));
+
+} // namespace ymir::scu

--- a/libs/ymir-core/src/ymir/hw/scu/scu.cpp
+++ b/libs/ymir-core/src/ymir/hw/scu/scu.cpp
@@ -276,7 +276,7 @@ void SCU::AcknowledgeExternalInterrupt() {
 
 void SCU::DumpDSPProgramRAM(std::ostream &out) const {
     for (uint32 i = 0; i < m_dsp.programRAM.size(); ++i) {
-        const uint32 value = bit::big_endian_swap(m_dsp.programRAM[i]);
+        const uint32 value = bit::big_endian_swap(m_dsp.programRAM[i].u32);
         out.write((const char *)&value, sizeof(value));
     }
 }

--- a/tests/ymir-core-tests/src/hw/scu/scu_dsp_tests.cpp
+++ b/tests/ymir-core-tests/src/hw/scu/scu_dsp_tests.cpp
@@ -1090,7 +1090,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP ALU operations compute correc
 // -----------------------------------------------------------------------------
 
 struct DSPState {
-    std::array<uint32, 256> programRAM;
+    std::array<scu::DSPInstr, 256> programRAM;
     std::array<std::array<uint32, 64>, 4> dataRAM;
 
     uint8 PC; // program address
@@ -1204,8 +1204,8 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP loop instructions execute cor
     ClearAll();
 
     SECTION("LPS") {
-        dsp.programRAM[0] = 0xE8000000; // LPS
-        dsp.programRAM[1] = 0x10040000; // ADD  MOV ALU,A
+        dsp.programRAM[0].u32 = 0xE8000000; // LPS
+        dsp.programRAM[1].u32 = 0x10040000; // ADD  MOV ALU,A
         dsp.AC.u64 = 1;
         dsp.P.u64 = 1;
         dsp.loopCount = 2;
@@ -1282,10 +1282,10 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP loop instructions execute cor
     }
 
     SECTION("BTM") {
-        dsp.programRAM[0] = 0x00000000; // NOP
-        dsp.programRAM[1] = 0x10040000; // ADD  MOV ALU,A
-        dsp.programRAM[2] = 0xE0000000; // BTM
-        dsp.programRAM[3] = 0x28040000; // SL   MOV ALU,A
+        dsp.programRAM[0].u32 = 0x00000000; // NOP
+        dsp.programRAM[1].u32 = 0x10040000; // ADD  MOV ALU,A
+        dsp.programRAM[2].u32 = 0xE0000000; // BTM
+        dsp.programRAM[3].u32 = 0x28040000; // SL   MOV ALU,A
         dsp.AC.u64 = 1;
         dsp.P.u64 = 1;
         dsp.loopTop = 1;
@@ -1399,7 +1399,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP end instructions execute corr
     ClearAll();
 
     SECTION("END") {
-        dsp.programRAM[0] = 0xF0000000; // END
+        dsp.programRAM[0].u32 = 0xF0000000; // END
 
         // Setup execution
         dsp.PC = 0;
@@ -1417,7 +1417,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP end instructions execute corr
     }
 
     SECTION("ENDI") {
-        dsp.programRAM[0] = 0xF8000000; // ENDI
+        dsp.programRAM[0].u32 = 0xF8000000; // ENDI
 
         // Setup execution
         dsp.PC = 0;
@@ -1439,7 +1439,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     ClearAll();
 
     SECTION("DMA MC0,D0,#1 (invalid region)") {
-        dsp.programRAM[0] = 0xC0001001;
+        dsp.programRAM[0].u32 = 0xC0001001;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -1491,7 +1491,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA MC0,D0,#1 (A-Bus)") {
-        dsp.programRAM[0] = 0xC0001001;
+        dsp.programRAM[0].u32 = 0xC0001001;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -1544,7 +1544,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA MC0,D0,#1 (B-Bus)") {
-        dsp.programRAM[0] = 0xC0001001;
+        dsp.programRAM[0].u32 = 0xC0001001;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -1598,7 +1598,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA MC0,D0,#1 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0001001;
+        dsp.programRAM[0].u32 = 0xC0001001;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -1651,7 +1651,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA MC1,D0,#1 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0001101;
+        dsp.programRAM[0].u32 = 0xC0001101;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -1704,7 +1704,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA MC2,D0,#1 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0001201;
+        dsp.programRAM[0].u32 = 0xC0001201;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -1757,7 +1757,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA MC3,D0,#1 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0001301;
+        dsp.programRAM[0].u32 = 0xC0001301;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -1810,7 +1810,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA MC3,D0,#4 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0011304;
+        dsp.programRAM[0].u32 = 0xC0011304;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -1866,7 +1866,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMAH MC3,D0,#4 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0015304;
+        dsp.programRAM[0].u32 = 0xC0015304;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -1922,7 +1922,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA MC0,D0,M0 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0013000;
+        dsp.programRAM[0].u32 = 0xC0013000;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -1975,7 +1975,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA MC0,D0,M1 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0013001;
+        dsp.programRAM[0].u32 = 0xC0013001;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[0][1] = 11;
         dsp.dataRAM[0][2] = 21;
@@ -2032,7 +2032,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA MC0,D0,M2 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0013002;
+        dsp.programRAM[0].u32 = 0xC0013002;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[0][1] = 11;
         dsp.dataRAM[0][2] = 21;
@@ -2095,7 +2095,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA MC0,D0,M3 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0013003;
+        dsp.programRAM[0].u32 = 0xC0013003;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[0][1] = 11;
         dsp.dataRAM[0][2] = 21;
@@ -2167,7 +2167,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
 
     // TODO: check this on hardware; is it supposed to preincrement MC0 and read from data RAM[0][1]?
     SECTION("DMA MC0,D0,MC0 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0013004;
+        dsp.programRAM[0].u32 = 0xC0013004;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[0][1] = 11;
         dsp.dataRAM[1][0] = 2;
@@ -2221,7 +2221,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA MC0,D0,MC1 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0013005;
+        dsp.programRAM[0].u32 = 0xC0013005;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[0][1] = 11;
         dsp.dataRAM[0][2] = 21;
@@ -2278,7 +2278,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA MC0,D0,MC2 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0013006;
+        dsp.programRAM[0].u32 = 0xC0013006;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[0][1] = 11;
         dsp.dataRAM[0][2] = 21;
@@ -2341,7 +2341,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA MC0,D0,MC3 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0013007;
+        dsp.programRAM[0].u32 = 0xC0013007;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[0][1] = 11;
         dsp.dataRAM[0][2] = 21;
@@ -2412,7 +2412,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMAH MC0,D0,MC3 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0017007;
+        dsp.programRAM[0].u32 = 0xC0017007;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[0][1] = 11;
         dsp.dataRAM[0][2] = 21;
@@ -2483,7 +2483,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA D0,MC0,#1 (invalid region)") {
-        dsp.programRAM[0] = 0xC0000001;
+        dsp.programRAM[0].u32 = 0xC0000001;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -2536,7 +2536,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA D0,MC0,#1 (A-Bus)") {
-        dsp.programRAM[0] = 0xC0000001;
+        dsp.programRAM[0].u32 = 0xC0000001;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -2592,7 +2592,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA D0,MC0,#1 (B-Bus)") {
-        dsp.programRAM[0] = 0xC0000001;
+        dsp.programRAM[0].u32 = 0xC0000001;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -2650,7 +2650,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA D0,MC0,#1 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0000001;
+        dsp.programRAM[0].u32 = 0xC0000001;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -2706,7 +2706,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA D0,MC1,#1 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0000101;
+        dsp.programRAM[0].u32 = 0xC0000101;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -2762,7 +2762,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA D0,MC2,#1 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0000201;
+        dsp.programRAM[0].u32 = 0xC0000201;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -2818,7 +2818,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA D0,MC3,#1 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0000301;
+        dsp.programRAM[0].u32 = 0xC0000301;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -2874,7 +2874,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA D0,MC3,#4 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0010304;
+        dsp.programRAM[0].u32 = 0xC0010304;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -2939,7 +2939,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMAH D0,MC3,#4 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0014304;
+        dsp.programRAM[0].u32 = 0xC0014304;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -3004,7 +3004,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA D0,MC0,M0 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0012000;
+        dsp.programRAM[0].u32 = 0xC0012000;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -3060,7 +3060,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
     }
 
     SECTION("DMA D0,PRG,M0 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0012400;
+        dsp.programRAM[0].u32 = 0xC0012400;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -3111,13 +3111,13 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
         CHECK(dsp.dmaReadAddr == 0x6001004);  // no hold = update address
         CHECK(dsp.dmaWriteAddr == 0x6002000); // not used = maintain address
         CHECK(dsp.dataRAM[0][0] == 1);
-        CHECK(dsp.programRAM[0] == 0x12345678);
+        CHECK(dsp.programRAM[0].u32 == 0x12345678);
         REQUIRE(memoryAccesses.size() == 1);
         CHECK(memoryAccesses[0] == MemoryAccessInfo{0x6001000, 0x12345678, false, sizeof(uint32)});
     }
 
     SECTION("DMAH D0,PRG,M0 (WRAM High)") {
-        dsp.programRAM[0] = 0xC0016400;
+        dsp.programRAM[0].u32 = 0xC0016400;
         dsp.dataRAM[0][0] = 1;
         dsp.dataRAM[1][0] = 2;
         dsp.dataRAM[1][1] = 3;
@@ -3168,7 +3168,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP DMA transfers execute correct
         CHECK(dsp.dmaReadAddr == 0x6001000);  // hold = maintain address
         CHECK(dsp.dmaWriteAddr == 0x6002000); // not used = maintain address
         CHECK(dsp.dataRAM[0][0] == 1);
-        CHECK(dsp.programRAM[0] == 0x12345678);
+        CHECK(dsp.programRAM[0].u32 == 0x12345678);
         REQUIRE(memoryAccesses.size() == 1);
         CHECK(memoryAccesses[0] == MemoryAccessInfo{0x6001000, 0x12345678, false, sizeof(uint32)});
     }


### PR DESCRIPTION
Using a bit-field type rather than `bit_extract` emits more optimal assembly in the general-case for both debug/release cases and simplifies code required to decode and implement instructions. This follows a similar pattern as the `scsp_dsp_instr.hpp` header.

In this case(arm64), rather than calls to `bit_extract`, instructions like `ubfx`, `sbfx`, `and`, and `tbz` are used to directly extract bits for a good little chunk of perf gains here.

![Screenshot 2025-05-17 160006](https://github.com/user-attachments/assets/dda80b15-c2bb-43b7-a0b4-f4c75fccf285)
![Screenshot 2025-05-17 160435](https://github.com/user-attachments/assets/ac931f0e-5383-4e4b-81ba-a389a6b527d9)
![Screenshot 2025-05-17 174848](https://github.com/user-attachments/assets/45d6fb57-ebc8-4ca5-916e-fec53353f372)
