### PR TITLE
fix: Take override paths into account when checking and creating folders

### DIFF
--- a/apps/ymir-sdl3/src/app/app.cpp
+++ b/apps/ymir-sdl3/src/app/app.cpp
@@ -162,15 +162,7 @@ int App::Run(const CommandLineOptions &options) {
     } else {
         m_context.profile.UsePortableProfilePath();
     }
-    if (!m_context.profile.CheckFolders()) {
-        std::error_code error{};
-        if (!m_context.profile.CreateFolders(error)) {
-            devlog::error<grp::base>("Could not create profile folders: {}", error.message());
-            return -1;
-        }
-    }
 
-    devlog::debug<grp::base>("Profile directory: {}", m_context.profile.GetPath(ProfilePath::Root));
 
     {
         auto &inputSettings = m_context.settings.input;
@@ -199,6 +191,16 @@ int App::Run(const CommandLineOptions &options) {
             devlog::warn<grp::base>("Failed to save settings: {}", result.string());
         }
     }};
+
+    if (!m_context.profile.CheckFolders()) {
+        std::error_code error{};
+        if (!m_context.profile.CreateFolders(error)) {
+            devlog::error<grp::base>("Could not create profile folders: {}", error.message());
+            return -1;
+        }
+    }
+
+    devlog::debug<grp::base>("Profile directory: {}", m_context.profile.GetPath(ProfilePath::Root));
 
     m_context.saturn.UsePreferredRegion();
 

--- a/apps/ymir-sdl3/src/app/profile.cpp
+++ b/apps/ymir-sdl3/src/app/profile.cpp
@@ -41,8 +41,13 @@ void Profile::UseProfilePath(std::filesystem::path path) {
 }
 
 bool Profile::CheckFolders() const {
-    for (auto &suffix : kPathSuffixes) {
-        if (!std::filesystem::is_directory(m_profilePath / suffix)) {
+    for (size_t i = 0; i < static_cast<size_t>(ProfilePath::_Count); ++i) {
+
+        if (!m_pathOverrides[i].empty() && !std::filesystem::is_directory(m_pathOverrides[i]))
+        {
+            return false;
+        } else if (!std::filesystem::is_directory(m_profilePath / kPathSuffixes[i]))
+        {
             return false;
         }
     }
@@ -52,8 +57,14 @@ bool Profile::CheckFolders() const {
 bool Profile::CreateFolders(std::error_code &error) {
     error.clear();
 
-    for (auto &suffix : kPathSuffixes) {
-        std::filesystem::create_directories(m_profilePath / suffix, error);
+    for (size_t i = 0; i < static_cast<size_t>(ProfilePath::_Count); ++i) {
+        if (m_pathOverrides[i].empty()) {
+            std::filesystem::create_directories(m_profilePath / kPathSuffixes[i], error);
+        } else if (!std::filesystem::is_directory(m_pathOverrides[i])) {
+            std::filesystem::create_directories(m_pathOverrides[i], error);
+        }
+
+
         if (error) {
             return false;
         }


### PR DESCRIPTION
Updates `CheckFolders()` and `CreateFolders()` to take set override paths into account. Moves the `CheckFolders()` and `CreateFolders()` calls to after the config loads.

Resolves #119 