### PR TITLE
feat(VDP): Refactor `VDP2ComposeLine` into separable passes

### DIFF
--- a/libs/ymir-core/include/ymir/hw/vdp/vdp.hpp
+++ b/libs/ymir-core/include/ymir/hw/vdp/vdp.hpp
@@ -859,7 +859,16 @@ private:
     };
 
     // Layer state indices
-    enum LayerIndex { LYR_Sprite, LYR_RBG0, LYR_NBG0_RBG1, LYR_NBG1_EXBG, LYR_NBG2, LYR_NBG3, LYR_Back, LYR_LineColor };
+    enum LayerIndex : uint8 {
+        LYR_Sprite,
+        LYR_RBG0,
+        LYR_NBG0_RBG1,
+        LYR_NBG1_EXBG,
+        LYR_NBG2,
+        LYR_NBG3,
+        LYR_Back,
+        LYR_LineColor,
+    };
 
     // Common layer states
     //     RBG0+RBG1   RBG0        no RBGs

--- a/libs/ymir-core/include/ymir/hw/vdp/vdp_defs.hpp
+++ b/libs/ymir-core/include/ymir/hw/vdp/vdp_defs.hpp
@@ -44,6 +44,7 @@ union Color555 {
         uint16 msb : 1; // CC in CRAM, transparency in cells when using RGB format
     };
 };
+static_assert(sizeof(Color555) == sizeof(uint16));
 
 union Color888 {
     uint32 u32;
@@ -55,6 +56,7 @@ union Color888 {
         uint32 msb : 1; // CC in CRAM, transparency in cells when using RGB format
     };
 };
+static_assert(sizeof(Color888) == sizeof(uint32));
 
 FORCE_INLINE Color888 ConvertRGB555to888(Color555 color) {
     return Color888{

--- a/libs/ymir-core/src/ymir/hw/vdp/vdp.cpp
+++ b/libs/ymir-core/src/ymir/hw/vdp/vdp.cpp
@@ -3436,6 +3436,21 @@ FORCE_INLINE void VDP::VDP2ComposeLine(uint32 y) {
         layer2Pixels[x] = getLayerColor(scanline_layers[x][2]);
     }
 
+    // Apply Extended color calc to layer 1
+    if (useExtendedColorCalc) {
+        for (uint32 x = 0; x < m_HRes; ++x) {
+            Color888 &pixel = layer1Pixels[x];
+            // TODO: honor color RAM mode + palette/RGB format restrictions
+            // - modes 1 and 2 don't blend layers if the bottom layer uses palette color
+
+            // HACK: assuming color RAM mode 0 for now (aka no restrictions)
+            const Color888 &l2Color = layer2Pixels[x];
+            pixel.r = (pixel.r + l2Color.r) / 2;
+            pixel.g = (pixel.g + l2Color.g) / 2;
+            pixel.b = (pixel.b + l2Color.b) / 2;
+        }
+    }
+
     // Gather line-color data
     alignas(16) std::bitset<kMaxResH> layer0LineColorEnabled = {};
     alignas(16) std::array<Color888, kMaxResH> layer0LineColors = {};
@@ -3466,6 +3481,31 @@ FORCE_INLINE void VDP::VDP2ComposeLine(uint32 y) {
 
         layer0LineColorEnabled[x] = isLineColorEnabled(scanline_layers[x][0]);
         layer0LineColors[x] = getLineColor(scanline_layers[x][0]);
+    }
+
+    // Blend line color screen if top layer uses it
+    if (layer0LineColorEnabled.any()) {
+        if (useExtendedColorCalc) {
+            // Average color
+            // TODO: _mm_avg_epu8(pavgb)
+            for (uint32 x = 0; x < m_HRes; ++x) {
+                Color888 &pixel = layer1Pixels[x];
+                const Color888 &lineColor = layer0LineColors[x];
+                pixel.r = (lineColor.r + pixel.r) / 2;
+                pixel.g = (lineColor.g + pixel.g) / 2;
+                pixel.b = (lineColor.b + pixel.b) / 2;
+            }
+        } else {
+            // Alpha composite
+            for (uint32 x = 0; x < m_HRes; ++x) {
+                Color888 &pixel = layer1Pixels[x];
+                const Color888 &lineColor = layer0LineColors[x];
+                const uint8 ratio = regs.lineScreenParams.colorCalcRatio;
+                pixel.r = lineColor.r + ((int)pixel.r - (int)lineColor.r) * ratio / 32;
+                pixel.g = lineColor.g + ((int)pixel.g - (int)lineColor.g) * ratio / 32;
+                pixel.b = lineColor.b + ((int)pixel.b - (int)lineColor.b) * ratio / 32;
+            }
+        }
     }
 
     // Gather shadow data
@@ -3553,56 +3593,40 @@ FORCE_INLINE void VDP::VDP2ComposeLine(uint32 y) {
 
     const std::span<Color888> framebufferOutput(reinterpret_cast<Color888 *>(&m_framebuffer[y * m_HRes]), m_HRes);
 
+    // Blend layer 0 and layer 1
     if (layer0ColorCalcEnabled.any()) {
-        for (uint32 x = 0; Color888 & outputColor : framebufferOutput) {
-            // Calculate color
-            if (layer0ColorCalcEnabled[x]) {
+        if (colorCalcParams.useAdditiveBlend) {
+            // Saturated add
+            // TODO: _mm_adds_epi8(paddsb)
+            for (uint32 x = 0; Color888 & outputColor : framebufferOutput) {
                 const Color888 &topColor = layer0Pixels[x];
-                Color888 btmColor = layer1Pixels[x];
+                const Color888 &btmColor = layer1Pixels[x];
 
-                if (useExtendedColorCalc) {
-                    // TODO: honor color RAM mode + palette/RGB format restrictions
-                    // - modes 1 and 2 don't blend layers if the bottom layer uses palette color
-
-                    // HACK: assuming color RAM mode 0 for now (aka no restrictions)
-                    if (layer1ColorCalcEnabled[x]) {
-                        const Color888 &l2Color = layer2Pixels[x];
-                        btmColor.r = (btmColor.r + l2Color.r) / 2;
-                        btmColor.g = (btmColor.g + l2Color.g) / 2;
-                        btmColor.b = (btmColor.b + l2Color.b) / 2;
-                    }
-                }
-
-                // Insert and blend line color screen if top layer uses it
-                if (layer0LineColorEnabled[x]) {
-                    const Color888 &lineColor = layer0LineColors[x];
-                    if (useExtendedColorCalc) {
-                        btmColor.r = (lineColor.r + btmColor.r) / 2;
-                        btmColor.g = (lineColor.g + btmColor.g) / 2;
-                        btmColor.b = (lineColor.b + btmColor.b) / 2;
-                    } else {
-                        const uint8 ratio = regs.lineScreenParams.colorCalcRatio;
-                        btmColor.r = lineColor.r + ((int)btmColor.r - (int)lineColor.r) * ratio / 32;
-                        btmColor.g = lineColor.g + ((int)btmColor.g - (int)lineColor.g) * ratio / 32;
-                        btmColor.b = lineColor.b + ((int)btmColor.b - (int)lineColor.b) * ratio / 32;
-                    }
-                }
-
-                // Blend top and blended bottom layers
-                if (colorCalcParams.useAdditiveBlend) {
+                if (layer0ColorCalcEnabled[x]) {
                     outputColor.r = std::min<uint32>(topColor.r + btmColor.r, 255u);
                     outputColor.g = std::min<uint32>(topColor.g + btmColor.g, 255u);
                     outputColor.b = std::min<uint32>(topColor.b + btmColor.b, 255u);
                 } else {
+                    outputColor = topColor;
+                }
+                ++x;
+            }
+        } else {
+            // Alpha composite
+            for (uint32 x = 0; Color888 & outputColor : framebufferOutput) {
+                const Color888 &topColor = layer0Pixels[x];
+                const Color888 &btmColor = layer1Pixels[x];
+
+                if (layer0ColorCalcEnabled[x]) {
                     const uint8 &ratio = scanline_ratio[x];
                     outputColor.r = btmColor.r + ((int)topColor.r - (int)btmColor.r) * ratio / 32;
                     outputColor.g = btmColor.g + ((int)topColor.g - (int)btmColor.g) * ratio / 32;
                     outputColor.b = btmColor.b + ((int)topColor.b - (int)btmColor.b) * ratio / 32;
+                } else {
+                    outputColor = topColor;
                 }
-            } else {
-                outputColor = layer0Pixels[x];
+                ++x;
             }
-            ++x;
         }
     } else {
         std::copy_n(layer0Pixels.cbegin(), framebufferOutput.size(), framebufferOutput.begin());

--- a/libs/ymir-core/src/ymir/hw/vdp/vdp.cpp
+++ b/libs/ymir-core/src/ymir/hw/vdp/vdp.cpp
@@ -3439,12 +3439,13 @@ FORCE_INLINE void VDP::VDP2ComposeLine(uint32 y) {
     // Apply Extended color calc to layer 1
     if (useExtendedColorCalc) {
         for (uint32 x = 0; x < m_HRes; ++x) {
-            Color888 &pixel = layer1Pixels[x];
             // TODO: honor color RAM mode + palette/RGB format restrictions
             // - modes 1 and 2 don't blend layers if the bottom layer uses palette color
 
             // HACK: assuming color RAM mode 0 for now (aka no restrictions)
             const Color888 &l2Color = layer2Pixels[x];
+            // TODO: _mm_avg_epu8(pavgb)
+            Color888 &pixel = layer1Pixels[x];
             pixel.r = (pixel.r + l2Color.r) / 2;
             pixel.g = (pixel.g + l2Color.g) / 2;
             pixel.b = (pixel.b + l2Color.b) / 2;
@@ -3483,14 +3484,14 @@ FORCE_INLINE void VDP::VDP2ComposeLine(uint32 y) {
         layer0LineColors[x] = getLineColor(scanline_layers[x][0]);
     }
 
-    // Blend line color screen if top layer uses it
+    // Blend line color if top layer uses it
     if (layer0LineColorEnabled.any()) {
         if (useExtendedColorCalc) {
             // Average color
             // TODO: _mm_avg_epu8(pavgb)
             for (uint32 x = 0; x < m_HRes; ++x) {
-                Color888 &pixel = layer1Pixels[x];
                 const Color888 &lineColor = layer0LineColors[x];
+                Color888 &pixel = layer1Pixels[x];
                 pixel.r = (lineColor.r + pixel.r) / 2;
                 pixel.g = (lineColor.g + pixel.g) / 2;
                 pixel.b = (lineColor.b + pixel.b) / 2;
@@ -3498,9 +3499,9 @@ FORCE_INLINE void VDP::VDP2ComposeLine(uint32 y) {
         } else {
             // Alpha composite
             for (uint32 x = 0; x < m_HRes; ++x) {
-                Color888 &pixel = layer1Pixels[x];
                 const Color888 &lineColor = layer0LineColors[x];
                 const uint8 ratio = regs.lineScreenParams.colorCalcRatio;
+                Color888 &pixel = layer1Pixels[x];
                 pixel.r = lineColor.r + ((int)pixel.r - (int)lineColor.r) * ratio / 32;
                 pixel.g = lineColor.g + ((int)pixel.g - (int)lineColor.g) * ratio / 32;
                 pixel.b = lineColor.b + ((int)pixel.b - (int)lineColor.b) * ratio / 32;
@@ -3636,9 +3637,11 @@ FORCE_INLINE void VDP::VDP2ComposeLine(uint32 y) {
     if (layer0ShadowEnabled.any()) {
         for (uint32 x = 0; Color888 & outputColor : framebufferOutput) {
             if (layer0ShadowEnabled[x]) {
-                outputColor.r >>= 1u;
-                outputColor.g >>= 1u;
-                outputColor.b >>= 1u;
+                // outputColor.r >>= 1u;
+                // outputColor.g >>= 1u;
+                // outputColor.b >>= 1u;
+                outputColor.u32 >>= 1;
+                outputColor.u32 &= 0x7F'7F'7F'7F;
             }
             ++x;
         }

--- a/libs/ymir-core/src/ymir/hw/vdp/vdp.cpp
+++ b/libs/ymir-core/src/ymir/hw/vdp/vdp.cpp
@@ -3365,8 +3365,12 @@ FORCE_INLINE void VDP::VDP2ComposeLine(uint32 y) {
     }
 
     // Determine layer orders
-    alignas(16) std::array<std::array<LayerIndex, 3>, kMaxResH> scanline_layers = {LYR_Back, LYR_Back, LYR_Back};
-    alignas(16) std::array<std::array<uint8, 3>, kMaxResH> scanline_layerPrios = {0, 0, 0};
+    alignas(16) std::array<std::array<LayerIndex, 3>, kMaxResH> scanline_layers;
+    scanline_layers.fill({LYR_Back, LYR_Back, LYR_Back});
+
+    alignas(16) std::array<std::array<uint8, 3>, kMaxResH> scanline_layerPrios;
+    scanline_layerPrios.fill({0, 0, 0});
+
     for (uint32 x = 0; x < m_HRes; x++) {
         std::array<LayerIndex, 3> &layers = scanline_layers[x];
         std::array<uint8, 3> &layerPrios = scanline_layerPrios[x];

--- a/libs/ymir-core/src/ymir/hw/vdp/vdp.cpp
+++ b/libs/ymir-core/src/ymir/hw/vdp/vdp.cpp
@@ -3352,6 +3352,10 @@ static const auto kColorOffsetLUT = [] {
 
 FORCE_INLINE void VDP::VDP2ComposeLine(uint32 y) {
     const VDP2Regs &regs = VDP2GetRegs();
+    const auto &colorCalcParams = regs.colorCalcParams;
+
+    // Extended color calculations (only in normal TV modes)
+    const bool useExtendedColorCalc = colorCalcParams.extendedColorCalcEnable && regs.TVMD.HRESOn < 2;
 
     y = VDP2GetY(y);
 
@@ -3360,12 +3364,13 @@ FORCE_INLINE void VDP::VDP2ComposeLine(uint32 y) {
         return;
     }
 
-    uint32 *fbPtr = &m_framebuffer[y * m_HRes];
+    // Determine layer orders
+    alignas(16) std::array<std::array<LayerIndex, 3>, kMaxResH> scanline_layers = {LYR_Back, LYR_Back, LYR_Back};
+    alignas(16) std::array<std::array<uint8, 3>, kMaxResH> scanline_layerPrios = {0, 0, 0};
     for (uint32 x = 0; x < m_HRes; x++) {
-        std::array<LayerIndex, 3> layers = {LYR_Back, LYR_Back, LYR_Back};
-        std::array<uint8, 3> layerPrios = {0, 0, 0};
+        std::array<LayerIndex, 3> &layers = scanline_layers[x];
+        std::array<uint8, 3> &layerPrios = scanline_layerPrios[x];
 
-        // Determine layer order
         for (int layer = 0; layer < m_layerStates.size(); layer++) {
             const LayerState &state = m_layerStates[layer];
             if (!state.enabled) {
@@ -3403,7 +3408,14 @@ FORCE_INLINE void VDP::VDP2ComposeLine(uint32 y) {
                 }
             }
         }
+    }
 
+    // Gather pixels for each layer
+    alignas(16) std::array<Color888, kMaxResH> layer0Pixels = {};
+    alignas(16) std::array<Color888, kMaxResH> layer1Pixels = {};
+    alignas(16) std::array<Color888, kMaxResH> layer2Pixels = {};
+
+    for (uint32 x = 0; x < m_HRes; x++) {
         // Retrieves the color of the given layer
         auto getLayerColor = [&](LayerIndex layer) -> Color888 {
             if (layer == LYR_Back) {
@@ -3415,39 +3427,15 @@ FORCE_INLINE void VDP::VDP2ComposeLine(uint32 y) {
             }
         };
 
-        auto isColorCalcEnabled = [&](LayerIndex layer) {
-            if (layer == LYR_Sprite) {
-                const SpriteParams &spriteParams = regs.spriteParams;
-                if (!spriteParams.colorCalcEnable) {
-                    return false;
-                }
+        layer0Pixels[x] = getLayerColor(scanline_layers[x][0]);
+        layer1Pixels[x] = getLayerColor(scanline_layers[x][1]);
+        layer2Pixels[x] = getLayerColor(scanline_layers[x][2]);
+    }
 
-                const Pixel &pixel = m_layerStates[LYR_Sprite].pixels[x];
-
-                using enum SpriteColorCalculationCondition;
-                switch (spriteParams.colorCalcCond) {
-                case PriorityLessThanOrEqual: return pixel.priority <= spriteParams.colorCalcValue;
-                case PriorityEqual: return pixel.priority == spriteParams.colorCalcValue;
-                case PriorityGreaterThanOrEqual: return pixel.priority >= spriteParams.colorCalcValue;
-                case MsbEqualsOne: return pixel.color.msb == 1;
-                default: util::unreachable();
-                }
-            } else if (layer == LYR_Back) {
-                return regs.backScreenParams.colorCalcEnable;
-            } else {
-                return regs.bgParams[layer - LYR_RBG0].colorCalcEnable;
-            }
-        };
-
-        auto getColorCalcRatio = [&](LayerIndex layer) {
-            if (layer == LYR_Sprite) {
-                return m_spriteLayerState.attrs[x].colorCalcRatio;
-            } else if (layer == LYR_Back) {
-                return regs.backScreenParams.colorCalcRatio;
-            } else {
-                return regs.bgParams[layer - LYR_RBG0].colorCalcRatio;
-            }
-        };
+    // Gather line-color data
+    alignas(16) std::bitset<kMaxResH> layer0LineColorEnabled = {};
+    alignas(16) std::array<Color888, kMaxResH> layer0LineColors = {};
+    for (uint32 x = 0; x < m_HRes; x++) {
 
         auto isLineColorEnabled = [&](LayerIndex layer) {
             if (layer == LYR_Sprite) {
@@ -3472,6 +3460,13 @@ FORCE_INLINE void VDP::VDP2ComposeLine(uint32 y) {
             }
         };
 
+        layer0LineColorEnabled[x] = isLineColorEnabled(scanline_layers[x][0]);
+        layer0LineColors[x] = getLineColor(scanline_layers[x][0]);
+    }
+
+    // Gather shadow data
+    alignas(16) std::bitset<kMaxResH> layer0ShadowEnabled = {};
+    for (uint32 x = 0; x < m_HRes; x++) {
         auto isShadowEnabled = [&](LayerIndex layer) {
             if (layer == LYR_Sprite) {
                 return m_spriteLayerState.attrs[x].shadowOrWindow;
@@ -3481,96 +3476,164 @@ FORCE_INLINE void VDP::VDP2ComposeLine(uint32 y) {
                 return regs.bgParams[layer - LYR_RBG0].shadowEnable;
             }
         };
+        const bool isNormalShadow = m_spriteLayerState.attrs[x].normalShadow;
+        const bool isMSBShadow = !regs.spriteParams.spriteWindowEnable && m_spriteLayerState.attrs[x].shadowOrWindow;
 
-        const bool isTopLayerColorCalcEnabled = [&] {
-            if (!isColorCalcEnabled(layers[0])) {
+        layer0ShadowEnabled[x] = isShadowEnabled(scanline_layers[x][0]) || isNormalShadow || isMSBShadow;
+    }
+
+    // Gether layer color calc data
+    alignas(16) std::bitset<kMaxResH> layer0ColorCalcEnabled = {};
+    alignas(16) std::bitset<kMaxResH> layer1ColorCalcEnabled = {};
+    for (uint32 x = 0; x < m_HRes; x++) {
+        const auto isColorCalcEnabled = [&](LayerIndex layer) {
+            if (layer == LYR_Sprite) {
+                const SpriteParams &spriteParams = regs.spriteParams;
+                if (!spriteParams.colorCalcEnable) {
+                    return false;
+                }
+
+                const Pixel &pixel = m_layerStates[LYR_Sprite].pixels[x];
+
+                using enum SpriteColorCalculationCondition;
+                switch (spriteParams.colorCalcCond) {
+                case PriorityLessThanOrEqual: return pixel.priority <= spriteParams.colorCalcValue;
+                case PriorityEqual: return pixel.priority == spriteParams.colorCalcValue;
+                case PriorityGreaterThanOrEqual: return pixel.priority >= spriteParams.colorCalcValue;
+                case MsbEqualsOne: return pixel.color.msb == 1;
+                default: util::unreachable();
+                }
+            } else if (layer == LYR_Back) {
+                return regs.backScreenParams.colorCalcEnable;
+            } else {
+                return regs.bgParams[layer - LYR_RBG0].colorCalcEnable;
+            }
+        };
+        const auto isTopLayerColorCalcEnabled = [&]() -> bool {
+            if (!isColorCalcEnabled(scanline_layers[x][0])) {
                 return false;
             }
             if (m_colorCalcWindow[x]) {
                 return false;
             }
-            if (layers[0] == LYR_Back || layers[0] == LYR_Sprite) {
+            if (scanline_layers[x][0] == LYR_Back || scanline_layers[x][0] == LYR_Sprite) {
                 return true;
             }
-            return m_layerStates[layers[0]].pixels[x].specialColorCalc;
-        }();
+            return m_layerStates[scanline_layers[x][0]].pixels[x].specialColorCalc;
+        };
+        layer0ColorCalcEnabled[x] = isTopLayerColorCalcEnabled();
+        layer1ColorCalcEnabled[x] = isColorCalcEnabled(scanline_layers[x][1]);
+    }
 
-        const auto &colorCalcParams = regs.colorCalcParams;
-
-        // Calculate color
-        Color888 outputColor{};
-        if (isTopLayerColorCalcEnabled) {
-            const Color888 topColor = getLayerColor(layers[0]);
-            Color888 btmColor = getLayerColor(layers[1]);
-
-            // Apply extended color calculations (only in normal TV modes)
-            const bool useExtendedColorCalc = colorCalcParams.extendedColorCalcEnable && regs.TVMD.HRESOn < 2;
-            if (useExtendedColorCalc) {
-                // TODO: honor color RAM mode + palette/RGB format restrictions
-                // - modes 1 and 2 don't blend layers if the bottom layer uses palette color
-
-                // HACK: assuming color RAM mode 0 for now (aka no restrictions)
-                if (isColorCalcEnabled(layers[1])) {
-                    const Color888 l2Color = getLayerColor(layers[2]);
-                    btmColor.r = (btmColor.r + l2Color.r) / 2;
-                    btmColor.g = (btmColor.g + l2Color.g) / 2;
-                    btmColor.b = (btmColor.b + l2Color.b) / 2;
-                }
-            }
-
-            // Insert and blend line color screen if top layer uses it
-            if (isLineColorEnabled(layers[0])) {
-                const Color888 lineColor = getLineColor(layers[0]);
-                if (useExtendedColorCalc) {
-                    btmColor.r = (lineColor.r + btmColor.r) / 2;
-                    btmColor.g = (lineColor.g + btmColor.g) / 2;
-                    btmColor.b = (lineColor.b + btmColor.b) / 2;
-                } else {
-                    const uint8 ratio = regs.lineScreenParams.colorCalcRatio;
-                    btmColor.r = lineColor.r + ((int)btmColor.r - (int)lineColor.r) * ratio / 32;
-                    btmColor.g = lineColor.g + ((int)btmColor.g - (int)lineColor.g) * ratio / 32;
-                    btmColor.b = lineColor.b + ((int)btmColor.b - (int)lineColor.b) * ratio / 32;
-                }
-            }
-
-            // Blend top and blended bottom layers
-            if (colorCalcParams.useAdditiveBlend) {
-                outputColor.r = std::min<uint32>(topColor.r + btmColor.r, 255u);
-                outputColor.g = std::min<uint32>(topColor.g + btmColor.g, 255u);
-                outputColor.b = std::min<uint32>(topColor.b + btmColor.b, 255u);
+    // Gather extended color ratio info
+    alignas(16) std::array<uint8, kMaxResH> scanline_ratio = {};
+    for (uint32 x = 0; x < m_HRes; x++) {
+        auto getColorCalcRatio = [&](LayerIndex layer) {
+            if (layer == LYR_Sprite) {
+                return m_spriteLayerState.attrs[x].colorCalcRatio;
+            } else if (layer == LYR_Back) {
+                return regs.backScreenParams.colorCalcRatio;
             } else {
-                const uint8 ratio = getColorCalcRatio(colorCalcParams.useSecondScreenRatio ? layers[1] : layers[0]);
-                outputColor.r = btmColor.r + ((int)topColor.r - (int)btmColor.r) * ratio / 32;
-                outputColor.g = btmColor.g + ((int)topColor.g - (int)btmColor.g) * ratio / 32;
-                outputColor.b = btmColor.b + ((int)topColor.b - (int)btmColor.b) * ratio / 32;
+                return regs.bgParams[layer - LYR_RBG0].colorCalcRatio;
             }
-        } else {
-            outputColor = getLayerColor(layers[0]);
-        }
+        };
+        scanline_ratio[x] =
+            getColorCalcRatio(colorCalcParams.useSecondScreenRatio ? scanline_layers[x][1] : scanline_layers[x][0]);
+    }
 
-        // Apply sprite shadow
-        if (isShadowEnabled(layers[0])) {
-            const bool isNormalShadow = m_spriteLayerState.attrs[x].normalShadow;
-            const bool isMSBShadow =
-                !regs.spriteParams.spriteWindowEnable && m_spriteLayerState.attrs[x].shadowOrWindow;
-            if (isNormalShadow || isMSBShadow) {
+    // Gather color offset info
+    alignas(16) std::bitset<kMaxResH> layer0ColorOffsetEnabled = {};
+    for (uint32 x = 0; x < m_HRes; x++) {
+        layer0ColorOffsetEnabled[x] = regs.colorOffsetEnable[scanline_layers[x][0]];
+    }
+
+    const std::span<Color888> framebufferOutput(reinterpret_cast<Color888 *>(&m_framebuffer[y * m_HRes]), m_HRes);
+
+    if (layer0ColorCalcEnabled.any()) {
+        for (uint32 x = 0; Color888 & outputColor : framebufferOutput) {
+            // Calculate color
+            if (layer0ColorCalcEnabled[x]) {
+                const Color888 &topColor = layer0Pixels[x];
+                Color888 btmColor = layer1Pixels[x];
+
+                if (useExtendedColorCalc) {
+                    // TODO: honor color RAM mode + palette/RGB format restrictions
+                    // - modes 1 and 2 don't blend layers if the bottom layer uses palette color
+
+                    // HACK: assuming color RAM mode 0 for now (aka no restrictions)
+                    if (layer1ColorCalcEnabled[x]) {
+                        const Color888 &l2Color = layer2Pixels[x];
+                        btmColor.r = (btmColor.r + l2Color.r) / 2;
+                        btmColor.g = (btmColor.g + l2Color.g) / 2;
+                        btmColor.b = (btmColor.b + l2Color.b) / 2;
+                    }
+                }
+
+                // Insert and blend line color screen if top layer uses it
+                if (layer0LineColorEnabled[x]) {
+                    const Color888 &lineColor = layer0LineColors[x];
+                    if (useExtendedColorCalc) {
+                        btmColor.r = (lineColor.r + btmColor.r) / 2;
+                        btmColor.g = (lineColor.g + btmColor.g) / 2;
+                        btmColor.b = (lineColor.b + btmColor.b) / 2;
+                    } else {
+                        const uint8 ratio = regs.lineScreenParams.colorCalcRatio;
+                        btmColor.r = lineColor.r + ((int)btmColor.r - (int)lineColor.r) * ratio / 32;
+                        btmColor.g = lineColor.g + ((int)btmColor.g - (int)lineColor.g) * ratio / 32;
+                        btmColor.b = lineColor.b + ((int)btmColor.b - (int)lineColor.b) * ratio / 32;
+                    }
+                }
+
+                // Blend top and blended bottom layers
+                if (colorCalcParams.useAdditiveBlend) {
+                    outputColor.r = std::min<uint32>(topColor.r + btmColor.r, 255u);
+                    outputColor.g = std::min<uint32>(topColor.g + btmColor.g, 255u);
+                    outputColor.b = std::min<uint32>(topColor.b + btmColor.b, 255u);
+                } else {
+                    const uint8 &ratio = scanline_ratio[x];
+                    outputColor.r = btmColor.r + ((int)topColor.r - (int)btmColor.r) * ratio / 32;
+                    outputColor.g = btmColor.g + ((int)topColor.g - (int)btmColor.g) * ratio / 32;
+                    outputColor.b = btmColor.b + ((int)topColor.b - (int)btmColor.b) * ratio / 32;
+                }
+            } else {
+                outputColor = layer0Pixels[x];
+            }
+            ++x;
+        }
+    } else {
+        std::copy_n(layer0Pixels.cbegin(), framebufferOutput.size(), framebufferOutput.begin());
+    }
+
+    // Apply sprite shadow
+    if (layer0ShadowEnabled.any()) {
+        for (uint32 x = 0; Color888 & outputColor : framebufferOutput) {
+            if (layer0ShadowEnabled[x]) {
                 outputColor.r >>= 1u;
                 outputColor.g >>= 1u;
                 outputColor.b >>= 1u;
             }
+            ++x;
         }
+    }
 
-        // Apply color offset if enabled
-        if (regs.colorOffsetEnable[layers[0]]) {
-            const auto &colorOffset = regs.colorOffset[regs.colorOffsetSelect[layers[0]]];
-            if (colorOffset.nonZero) {
-                outputColor.r = kColorOffsetLUT[colorOffset.r][outputColor.r];
-                outputColor.g = kColorOffsetLUT[colorOffset.g][outputColor.g];
-                outputColor.b = kColorOffsetLUT[colorOffset.b][outputColor.b];
+    // Apply color offset if enabled
+    if (layer0ColorOffsetEnabled.any()) {
+        for (uint32 x = 0; Color888 & outputColor : framebufferOutput) {
+            if (layer0ColorOffsetEnabled[x]) {
+                const auto &colorOffset = regs.colorOffset[regs.colorOffsetSelect[scanline_layers[x][0]]];
+                if (colorOffset.nonZero) {
+                    outputColor.r = kColorOffsetLUT[colorOffset.r][outputColor.r];
+                    outputColor.g = kColorOffsetLUT[colorOffset.g][outputColor.g];
+                    outputColor.b = kColorOffsetLUT[colorOffset.b][outputColor.b];
+                }
             }
+            ++x;
         }
+    }
 
-        fbPtr[x] = outputColor.u32 | 0xFF000000;
+    // Opaque alpha
+    for (Color888 &outputColor : framebufferOutput) {
+        outputColor.u32 |= 0xFF000000;
     }
 }
 
@@ -4007,8 +4070,8 @@ FORCE_INLINE VDP::Pixel VDP::VDP2FetchScrollBGPixel(const BGParams &bgParams, st
     // +---------+---------+   +----+----+----+----+
     //
     // Normal and rotation BGs are divided into planes in the exact configurations illustrated above.
-    // The BG's Map Offset Register is combined with the BG plane's Map Register (MPxxN#) to produce a base address for
-    // each plane:
+    // The BG's Map Offset Register is combined with the BG plane's Map Register (MPxxN#) to produce a base address
+    // for each plane:
     //   Address bits  Source
     //            8-6  Map Offset Register (MPOFN)
     //            5-0  Map Register (MPxxN#)
@@ -4045,16 +4108,16 @@ FORCE_INLINE VDP::Pixel VDP::VDP2FetchScrollBGPixel(const BGParams &bgParams, st
     // |4033|4034|  |4095|4096|   | 993| 994|  |1023|1024|
     // +----+----+..+----+----+   +----+----+..+----+----+
     //
-    // Pages contain 32x32 or 64x64 character patterns, which are groups of 1x1 or 2x2 cells, determined by Character
-    // Size in the Character Control Register (CHCTLA-B).
+    // Pages contain 32x32 or 64x64 character patterns, which are groups of 1x1 or 2x2 cells, determined by
+    // Character Size in the Character Control Register (CHCTLA-B).
     //
     // Pages always contain a total of 64x64 cells - a grid of 64x64 1x1 character patterns or 32x32 2x2 character
     // patterns. Because of this, pages always have 512x512 dots.
     //
     // Character patterns in a page are stored sequentially in VRAM left to right, top to bottom, as shown above.
     //
-    // fourCellChar specifies the size of the character patterns (1x1 when false, 2x2 when true) and, by extension, the
-    // dimensions of the page (32x32 or 64x64 respectively).
+    // fourCellChar specifies the size of the character patterns (1x1 when false, 2x2 when true) and, by extension,
+    // the dimensions of the page (32x32 or 64x64 respectively).
     //
     // 2x2 Character Pattern     1x1 C.P.
     // +---------+---------+   +---------+
@@ -4067,22 +4130,23 @@ FORCE_INLINE VDP::Pixel VDP::VDP2FetchScrollBGPixel(const BGParams &bgParams, st
     // |         |         |
     // +---------+---------+
     //
-    // Character patterns are groups of 1x1 or 2x2 cells, determined by Character Size in the Character Control Register
-    // (CHCTLA-B).
+    // Character patterns are groups of 1x1 or 2x2 cells, determined by Character Size in the Character Control
+    // Register (CHCTLA-B).
     //
     // Cells are stored sequentially in VRAM left to right, top to bottom, as shown above.
     //
-    // Character patterns contain a character number (15 bits), a palette number (7 bits, only used with 16 or 256 color
-    // palette modes), two special function bits (Special Priority and Special Color Calculation) and two flip bits
-    // (horizontal and vertical).
+    // Character patterns contain a character number (15 bits), a palette number (7 bits, only used with 16 or 256
+    // color palette modes), two special function bits (Special Priority and Special Color Calculation) and two flip
+    // bits (horizontal and vertical).
     //
-    // Character patterns can be one or two words long, as defined by Pattern Name Data Size in the Pattern Name Control
-    // Register (PNCN0-3, PNCR). When using one word characters, some of the data comes from supplementary registers.
+    // Character patterns can be one or two words long, as defined by Pattern Name Data Size in the Pattern Name
+    // Control Register (PNCN0-3, PNCR). When using one word characters, some of the data comes from supplementary
+    // registers.
     //
     // fourCellChar stores the character pattern size (1x1 when false, 2x2 when true).
     // twoWordChar determines if characters are one (false) or two (true) words long.
-    // extChar determines the length of the character data field in one word characters -- when true, they're extended
-    // by two bits, taking over the two flip bits.
+    // extChar determines the length of the character data field in one word characters -- when true, they're
+    // extended by two bits, taking over the two flip bits.
     //
     //           Cell
     // +--+--+--+--+--+--+--+--+


### PR DESCRIPTION
This refactors `VDP2ComposeLine` into multiple passes of "kernels" to better lend itself to SIMD optimizations and to opportunistically detect uniform control flow.

Conditionals are computed upfront into lists of `bool`s that can be checked quickly for uniformity(`all`/`any`/`none`). Entire passes can then be avoided depending on how uniform(or not) the conditional data is.

Ex, Doing advanced blending vs a simple memcpy if it is found that the entire scanline does not utilize blending. Avoiding the shadow pass, etc.

This structure also indicates some possible spots where the upstream data-layout can be improved to lend itself better to SIMD optimizations.

This helps with debug-performance in some cases by avoiding entire-passes when applicable and definitely helps with release-mode performance where the compiler emits vector-code with masked-operations using the conditional data

![devenv_Vp2iIZzdKt](https://github.com/user-attachments/assets/19c48df6-aed6-49ef-aa0d-122da0caf4e7)

Later on, some of these passes can be accelerated with explicit-SIMD code to make them even faster!