### PR TITLE
fix(VDP): Fix `AnyBool` on arm64

### DIFF
--- a/libs/ymir-core/src/ymir/hw/vdp/vdp.cpp
+++ b/libs/ymir-core/src/ymir/hw/vdp/vdp.cpp
@@ -3605,8 +3605,8 @@ FORCE_INLINE bool AnyBool(std::span<const bool> values) {
         const uint8x16x4_t vec64 = vld1q_u8_x4(reinterpret_cast<const uint8 *>(values.data()));
 
         // If the smallest value is not zero, then we have a true value
-        if ((vminvq_u8(vec64.val[0]) != 0u) || (vminvq_u8(vec64.val[1]) != 0u) || (vminvq_u8(vec64.val[2]) != 0u) ||
-            (vminvq_u8(vec64.val[3]) != 0u)) {
+        if ((vmaxvq_u8(vec64.val[0]) != 0u) || (vmaxvq_u8(vec64.val[1]) != 0u) || (vmaxvq_u8(vec64.val[2]) != 0u) ||
+            (vmaxvq_u8(vec64.val[3]) != 0u)) {
             return true;
         }
     }
@@ -3616,7 +3616,7 @@ FORCE_INLINE bool AnyBool(std::span<const bool> values) {
         const uint8x16_t vec16 = vld1q_u8(reinterpret_cast<const uint8 *>(values.data()));
 
         // If the smallest value is not zero, then we have a true value
-        if (vminvq_u8(vec16) != 0u) {
+        if (vmaxvq_u8(vec16) != 0u) {
             return true;
         }
     }


### PR DESCRIPTION
These `vminvq_u8` should be `vmaxvq_u8` to test if the highest value is `0` or not. Fixes graphical issues and broken scanlines on arm64 related to `AnyBool`-checks

Before:
![Screenshot 2025-05-31 200815](https://github.com/user-attachments/assets/17024228-84ed-47d8-9ac0-940a811bb8df)

After:
![Screenshot 2025-05-31 201826](https://github.com/user-attachments/assets/8484a610-4ee9-46b6-b918-e98a5c1d7c19)
