### PR TITLE
packaging: Add Desktop File

### DIFF
--- a/apps/ymir-sdl3/res/io.github.strikerx3.ymir.desktop
+++ b/apps/ymir-sdl3/res/io.github.strikerx3.ymir.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Exec=ymir-sdl3
+Icon=ymir
+Terminal=false
+Type=Application
+Categories=Game;Emulator;
+Name=Ymir
+GenericName=Sega Saturn Emulator
+Comment=A Sega Saturn Emulator


### PR DESCRIPTION
* Added desktop file in preparation for creating a Flatpak


A few notes:

- Currently missing an icon line, I didn't see any icons or logos in the repo. Is this planned at a later date?
- The naming here is a little odd but it follows the D-Bus specification (which Flathub uses and recommends) and the freedesktop specification. See https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names and https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent. 
    - Instead of using com.github, it uses io.github in accordance to the Flathub docs, https://docs.flatpak.org/en/latest/conventions.html
        - "While a project may be hosted on GitHub or GitLab, it does not have control over the github.com or gitlab.com domains. Instead, you should use io.github or io.gitlab as shown above."
- There are a couple hits for different ymir named software on Google, I don't know what the odds are of clashing with this one but using the `io.github.strikerx3.ymir.desktop` name does prevent any chance of clashing
- The desktop file doesn't have to be in the root folder, there are a couple other emulator projects with this file in various folders (RA was the only other project with it in the root folder). I wasn't sure what the best place was, if there's a preferred spot, happy to move it. 

Apologies for being overly verbose:)