### PR TITLE
packaging: Add Metainfo File

### DIFF
--- a/apps/ymir-sdl3/res/io.github.strikerx3.ymir.xml
+++ b/apps/ymir-sdl3/res/io.github.strikerx3.ymir.xml
@@ -1,0 +1,72 @@
+<component type="desktop-application">
+  <id>io.github.strikerx3.ymir</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <name>Ymir</name>
+  <summary>Sega Saturn Emulator</summary>
+  <description>
+    <p>Ymir is a work-in-progress Sega Saturn emulator. Ymir includes the following features:</p>
+    <ul>
+      <li>Load games from MAME CHD, BIN+CUE, IMG+CCD, MDF+MDS or ISO files</li>
+      <li>Automatic IPL (BIOS) ROM detection</li>
+      <li>Automatic region switching</li>
+      <li>Up to two players with standard Control Pads or 3D Control Pads on both ports (more to come)</li>
+      <li>Fully customizable keybindings</li>
+      <li>Backup RAM, DRAM and ROM cartridges (more to come)</li>
+      <li>Integrated backup memory manager to import and export saves, and transfer between internal and cartridge RAM</li>
+      <li>Save states</li>
+      <li>Rewinding (up to one minute at 60 fps), turbo speed, frame step (forwards and backwards)</li>
+      <li>Full screen mode with VRR support and low input lag</li>
+      <li>A work-in-progress feature-rich debugger</li>
+    </ul>
+  </description>
+  <launchable type="desktop-id">io.github.strikerx3.ymir.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/StrikerX3/Ymir/38eb06341e9611673cf106406fb0e44fc9d78462/docs/images/cd-player.png</image>
+      <caption>CD Player</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/StrikerX3/Ymir/0fb1230dd517cb1215bb4b2b24abfc4e43ee0731/docs/images/debugger.png</image>
+      <caption>Debugger</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/StrikerX3/Ymir/0fb1230dd517cb1215bb4b2b24abfc4e43ee0731/docs/images/nights-into-dreams.png</image>
+      <caption>Nights into Dreams</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/StrikerX3/Ymir/0fb1230dd517cb1215bb4b2b24abfc4e43ee0731/docs/images/panzer-dragoon-saga.png</image>
+      <caption>Panzer Dragoon Saga</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/StrikerX3/Ymir/0fb1230dd517cb1215bb4b2b24abfc4e43ee0731/docs/images/radiant-silvergun.png</image>
+      <caption>Radiant Silvergun</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/StrikerX3/Ymir/0fb1230dd517cb1215bb4b2b24abfc4e43ee0731/docs/images/sonic-r.png</image>
+      <caption>Sonic R</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/StrikerX3/Ymir/0fb1230dd517cb1215bb4b2b24abfc4e43ee0731/docs/images/virtua-fighter-2.png</image>
+      <caption>Virtua Fighter 2</caption>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://github.com/StrikerX3/Ymir</url>
+  <developer id="io.github.strikerx3">
+    <name>StrikerX3</name>
+  </developer>
+  <provides>
+    <binary>ymir-sdl3</binary>
+  </provides>
+  <releases>
+    <release version="0.1.3" date="2025-05-16">
+      <description/>
+      <url>https://github.com/StrikerX3/Ymir/releases/tag/v0.1.3</url>
+    </release>
+  </releases>
+  <categories>
+    <category>Game</category>
+    <category>Emulator</category>
+  </categories>
+  <content_rating type="oars-1.1"/>
+</component>


### PR DESCRIPTION
Added metainfo file in preparation for creating a Flatpak

Related PR: https://github.com/StrikerX3/Ymir/pull/188

Some notes:

- Flathub prefers this file to be upstreamed, see https://docs.flathub.org/docs/for-app-authors/requirements#required-metadata
- Used https://freedesktop.org/software/appstream/docs/chap-Metadata.html as a reference
- Used appstreamcli to validate the file
- Same deal with the desktop file, if there's a preferred location, happy to move it!