### PR TITLE
fix(app): Fix MacOS Retina Display support

### DIFF
--- a/apps/ymir-sdl3/src/app/app.cpp
+++ b/apps/ymir-sdl3/src/app/app.cpp
@@ -440,7 +440,7 @@ void App::RunEmulator() {
 
     // RescaleUI also loads the style and fonts
     bool rescaleUIPending = false;
-    RescaleUI(false);
+    RescaleUI(SDL_GetDisplayContentScale(SDL_GetPrimaryDisplay()), false);
     {
         auto &videoSettings = m_context.settings.video;
 
@@ -1415,9 +1415,11 @@ void App::RunEmulator() {
                 // evt.gsensor.data;
                 break;
 
+            case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED: [[fallthrough]];
             case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED:
                 if (!m_context.settings.video.overrideUIScale) {
-                    RescaleUI(true);
+                    const float windowScale = SDL_GetWindowDisplayScale(screen.window);
+                    RescaleUI(windowScale, true);
                 }
                 break;
             case SDL_EVENT_QUIT: goto end_loop; break;
@@ -1456,7 +1458,8 @@ void App::RunEmulator() {
         }
         if (rescaleUIPending) {
             rescaleUIPending = false;
-            RescaleUI(true);
+            const float windowScale = SDL_GetWindowDisplayScale(screen.window);
+            RescaleUI(windowScale, true);
         }
 
         // Process all axis changes
@@ -2613,14 +2616,11 @@ void App::RebindInputs() {
     m_context.settings.RebindInputs();
 }
 
-void App::RescaleUI(bool reloadFonts) {
-    float displayScale;
+void App::RescaleUI(float displayScale, bool reloadFonts) {
     if (m_context.settings.video.overrideUIScale) {
         displayScale = m_context.settings.video.uiScale;
-    } else {
-        displayScale = SDL_GetDisplayContentScale(SDL_GetPrimaryDisplay());
-        devlog::info<grp::base>("Primary display DPI scaling: {:.1f}%", displayScale * 100.0f);
     }
+    devlog::info<grp::base>("Window DPI scaling: {:.1f}%", displayScale * 100.0f);
 
     m_context.displayScale = displayScale;
     devlog::info<grp::base>("UI scaling set to {:.1f}%", m_context.displayScale * 100.0f);

--- a/apps/ymir-sdl3/src/app/app.cpp
+++ b/apps/ymir-sdl3/src/app/app.cpp
@@ -2203,7 +2203,7 @@ void App::RunEmulator() {
             const bool fitWindowToScreen =
                 (videoSettings.autoResizeWindow && screenSizeChanged) || fitWindowToScreenNow;
 
-            const float menuBarHeight = drawMainMenu ? ImGui::GetFrameHeight() : 0.0f;
+            float menuBarHeight = drawMainMenu ? ImGui::GetFrameHeight() : 0.0f;
 
             // Get window size
             int ww, wh;
@@ -2214,6 +2214,8 @@ void App::RunEmulator() {
             const float pixelDensity = SDL_GetWindowPixelDensity(screen.window);
             ww *= pixelDensity;
             wh *= pixelDensity;
+
+            menuBarHeight *= pixelDensity;
 #endif
 
             wh -= menuBarHeight;

--- a/apps/ymir-sdl3/src/app/app.cpp
+++ b/apps/ymir-sdl3/src/app/app.cpp
@@ -2208,6 +2208,14 @@ void App::RunEmulator() {
             // Get window size
             int ww, wh;
             SDL_GetWindowSize(screen.window, &ww, &wh);
+
+#if defined(__APPLE__)
+            // Logical->Physical window-coordinate fix primarily for MacOS Retina displays
+            const float pixelDensity = SDL_GetWindowPixelDensity(screen.window);
+            ww *= pixelDensity;
+            wh *= pixelDensity;
+#endif
+
             wh -= menuBarHeight;
 
             double scaleFactor = 1.0;
@@ -2296,7 +2304,17 @@ void App::RunEmulator() {
         screen.resolutionChanged = false;
 
         // Render ImGui widgets
+#if defined(__APPLE__)
+        // Logical->Physical window-coordinate fix primarily for MacOS Retina displays
+        const float pixelDensity = SDL_GetWindowPixelDensity(screen.window);
+        SDL_SetRenderScale(renderer, pixelDensity, pixelDensity);
+#endif
+
         ImGui_ImplSDLRenderer3_RenderDrawData(ImGui::GetDrawData(), renderer);
+
+#if defined(__APPLE__)
+        SDL_SetRenderScale(renderer, 1.0f, 1.0f);
+#endif
 
         SDL_RenderPresent(renderer);
 

--- a/apps/ymir-sdl3/src/app/app.hpp
+++ b/apps/ymir-sdl3/src/app/app.hpp
@@ -80,7 +80,7 @@ private:
 
     void RebindInputs();
 
-    void RescaleUI(bool reloadFonts);
+    void RescaleUI(float displayScale, bool reloadFonts);
     ImGuiStyle &ReloadStyle(float displayScale);
     void ReloadFonts(float displayScale);
 


### PR DESCRIPTION
Adds conversions from Logical window coordinates into "Real" pixel coordinates for Retina displays where relevant.

This fixes MacOS reporting a DPI of `1.0` despite window coordinates mapping to multiple pixels and applies the ImGui scaling mitigation found [here](https://github.com/ocornut/imgui/issues/7779).

Also acquires content scaling based on the _window_ rather than just the primary display. This allows the application to be more responsive to possible Multi-DPI setups or Per-Window DPI settings rather than using the Display Scaling of the primary display.

Before:
<img width="1111" alt="Screenshot 2025-06-24 at 7 08 13 AM" src="https://github.com/user-attachments/assets/bbd13fd6-397f-4e7f-8b79-4bd43391302e" />

After:
<img width="1111" alt="Screenshot 2025-06-24 at 7 09 59 AM" src="https://github.com/user-attachments/assets/68a63b62-58ed-45dd-a55a-20d742f0980d" />

Fixes https://github.com/StrikerX3/Ymir/issues/221