### PR TITLE
Implement multi-architecture builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,11 +8,11 @@ on:
         type: boolean
       build-version:
         required: false
-        default: ''
+        default: ""
         type: string
       prerelease-version:
         required: false
-        default: ''
+        default: ""
         type: string
 
 jobs:
@@ -62,7 +62,7 @@ jobs:
     steps:
       # Set up MASM for lzma
       - uses: glslang/setup-masm@v1
-  
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -159,7 +159,7 @@ jobs:
             enable_avx2_option: "ON"
             runner: ubuntu-22.04
           - name: "AArch64-NEON"
-            enable_avx2_option: "OFF"  # doesn't matter actually
+            enable_avx2_option: "OFF" # doesn't matter actually
             runner: ubuntu-22.04
         include:
           - c_compiler: clang
@@ -261,7 +261,7 @@ jobs:
         build_type: [Release]
         arch:
           - name: "universal"
-            isa_name: "x64;a64"
+            isa_name: "x86_64;arm64"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -250,7 +250,7 @@ jobs:
           path: ${{ steps.strings.outputs.ymir-artifact-name }}.tar.xz
 
   build-macos:
-    name: macos-${{ matrix.arch.isa_name }}
+    name: macos-${{ matrix.arch.name }}
     runs-on: macos-latest
     needs: [get-project-version]
 
@@ -261,7 +261,7 @@ jobs:
         build_type: [Release]
         arch:
           - name: "universal"
-            isa_name: "x86_64;arm64"
+            isa_name: "'x86_64;arm64'"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -260,10 +260,8 @@ jobs:
       matrix:
         build_type: [Release]
         arch:
-          - name: "arm64"
-            isa_name: "AArch64"
-          - name: "x86_64"
-            isa_name: "x86_64"
+          - name: "universal"
+            isa_name: "x64;a64"
 
     steps:
       - uses: actions/checkout@v4
@@ -276,14 +274,14 @@ jobs:
         run: |
           export BUILD_VERSION=${{ needs.get-project-version.outputs.project-version }}
           echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
-          echo "ymir-artifact-name=ymir-macos-${{ matrix.arch.isa_name }}-${BUILD_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "ymir-artifact-name=ymir-macos-${{ matrix.arch.name }}-${BUILD_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Configure CMake
         run: >
           cmake -B ${{ steps.strings.outputs.build-output-dir }}
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -DBUILD_SHARED_LIBS=OFF
-          -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch.name }}
+          -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch.isa_name }}
           -DYmir_ENABLE_IPO=ON
           -DYmir_ENABLE_DEVLOG=OFF
           -DYmir_ENABLE_IMGUI_DEMO=OFF

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,7 +171,7 @@ jobs:
         run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --parallel
 
   build-macos:
-    name: macos-${{ matrix.arch.isa_name }}
+    name: macos-${{ matrix.arch.name }}
     runs-on: macos-latest
 
     strategy:
@@ -179,10 +179,8 @@ jobs:
 
       matrix:
         arch:
-          - name: "arm64"
-            isa_name: "a64"
-          - name: "x86_64"
-            isa_name: "x64"
+          - name: "universal"
+            isa_name: "x64;a64"
 
     steps:
       - uses: actions/checkout@v4
@@ -200,7 +198,7 @@ jobs:
           cmake -B ${{ steps.strings.outputs.build-output-dir }}
           -DCMAKE_BUILD_TYPE=Debug
           -DBUILD_SHARED_LIBS=OFF
-          -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch.name }}
+          -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch.isa_name }}
           -DYmir_ENABLE_DEVLOG=OFF
           -DYmir_ENABLE_IMGUI_DEMO=OFF
           -DYmir_ENABLE_SANDBOX=OFF

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Set up MASM for lzma
       - uses: glslang/setup-masm@v1
-  
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -180,7 +180,7 @@ jobs:
       matrix:
         arch:
           - name: "universal"
-            isa_name: "x64;a64"
+            isa_name: "x86_64;arm64"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,7 +180,7 @@ jobs:
       matrix:
         arch:
           - name: "universal"
-            isa_name: "x86_64;arm64"
+            isa_name: "'x86_64;arm64'"
 
     steps:
       - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(Ymir VERSION 0.1.7)
 
 include(cmake/CMakeRC.cmake)
 include(cmake/CopyRuntimeDLLs.cmake)
+include(cmake/TargetConditionalSources.cmake)
 
 # CMake project structured adapted from Alex Reinking's SharedStaticStarter
 # GitHub: https://github.com/alexreinking/SharedStaticStarter
@@ -29,6 +30,11 @@ else ()
 endif ()
 message(STATUS "Ymir: Devlog ${Ymir_ENABLE_DEVLOG}")
 message(STATUS "Ymir: Extra inlining ${Ymir_EXTRA_INLINING}")
+
+# Create Universal Binary on MacOS
+if (APPLE)
+    set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
+endif ()
 
 # Detect target architectures
 # ARCHITECTURES may have multiple variables in the case of a multi-arch build

--- a/cmake/DefineWrapFile.cmake
+++ b/cmake/DefineWrapFile.cmake
@@ -1,0 +1,2 @@
+file(READ "${input_file}" file_contents)
+file(WRITE "${output_file}" "#if (${condition})\n${file_contents}\n#endif\n")

--- a/cmake/TargetConditionalSources.cmake
+++ b/cmake/TargetConditionalSources.cmake
@@ -1,0 +1,21 @@
+function (target_conditional_sources project condition)
+    foreach (input_file IN LISTS ARGN)
+        if (NOT IS_ABSOLUTE ${input_file})
+            set(input_file "${CMAKE_CURRENT_SOURCE_DIR}/${input_file}")
+        endif ()
+        
+        set(output_file "${CMAKE_CURRENT_BINARY_DIR}/generated/${input_file}")
+        add_custom_command(
+            OUTPUT "${output_file}"
+            COMMAND
+            ${CMAKE_COMMAND}
+            "-Dcondition=${condition}"
+            "-Dinput_file=${input_file}"
+            "-Doutput_file=${output_file}"
+            -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/DefineWrapFile.cmake"
+            DEPENDS "${input_file}"
+            VERBATIM
+        )
+        target_sources(${project} PRIVATE "${output_file}")
+    endforeach ()
+endfunction ()

--- a/vendor/xxHash/CMakeLists.txt
+++ b/vendor/xxHash/CMakeLists.txt
@@ -6,11 +6,20 @@ add_library(xxHash
 
 if ("x86_64" IN_LIST ARCHITECTURES)
     set(XXHSUM_DISPATCH ON)
-	target_conditional_sources(
-		xxHash "defined(__x86_64__) || defined(_M_X64)"
-		xxHash/xxh_x86dispatch.c
-		xxHash/xxh_x86dispatch.h
-	)
+	# Apple is the only target that supports fat binaries
+	if (APPLE)
+		target_conditional_sources(
+			xxHash "defined(__x86_64__) || defined(_M_X64)"
+			xxHash/xxh_x86dispatch.c
+			xxHash/xxh_x86dispatch.h
+		)
+	else()
+		target_sources(
+			xxHash PRIVATE
+			xxHash/xxh_x86dispatch.c
+			xxHash/xxh_x86dispatch.h
+		)
+	endif()
 	target_compile_definitions(xxHash PRIVATE XXHSUM_DISPATCH=1)
 endif ()
 

--- a/vendor/xxHash/CMakeLists.txt
+++ b/vendor/xxHash/CMakeLists.txt
@@ -6,7 +6,8 @@ add_library(xxHash
 
 if ("x86_64" IN_LIST ARCHITECTURES)
     set(XXHSUM_DISPATCH ON)
-	target_sources(xxHash PRIVATE
+	target_conditional_sources(
+		xxHash "defined(__x86_64__) || defined(_M_X64)"
 		xxHash/xxh_x86dispatch.c
 		xxHash/xxh_x86dispatch.h
 	)


### PR DESCRIPTION
Currently on MacOS, we have to create separate independent builds for each architecture(arm64/x64).
To have a fat-binary(universal binary) the same source files must be able to vary depending on the architecture. So x64-specific files must still be able to be compiled during an ARM64 build, and use a preprocessor mechanism of some sort to disable functionality.

Uses a pattern inspired by Dynarmic, CMake is able to create an intermediate file and add include-guards around specific files, causing them to resolve into empty files depending on the architecture.

Currently the only bit of code that was holding back having singular fat-binary builds is xxHash's x86-specific source files. The new `target_conditional_sources` is used to add x64-specific guards around these files without having to edit files within the submodule.

This now allows a singular MacOS binary to have both the x64 and Arm64 binaries built into it:

```
file ymir-sdl3
ymir-sdl3: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
ymir-sdl3 (for architecture x86_64):    Mach-O 64-bit executable x86_64
ymir-sdl3 (for architecture arm64):     Mach-O 64-bit executable arm64
```