### PR TITLE
feat(app): Use ISO 8601 screenshot file names

### DIFF
--- a/apps/ymir-sdl3/src/app/app.cpp
+++ b/apps/ymir-sdl3/src/app/app.cpp
@@ -1947,9 +1947,10 @@ void App::RunEmulator() {
                 auto localNow = util::to_local_time(now);
                 auto fracTime =
                     std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count() % 1000;
-                auto screenshotPath =
-                    m_context.profile.GetPath(ProfilePath::Screenshots) /
-                    fmt::format("{}-{:%Y%m%d-%H%M%S}_{}.png", m_context.GetGameFileName(), localNow, fracTime);
+                // ISO 8601 + milliseconds
+                auto screenshotPath = m_context.profile.GetPath(ProfilePath::Screenshots) /
+                                      fmt::format("{}-{:%Y%m%d}T{:%H%M%S}.{}.png", m_context.GetGameFileName(),
+                                                  localNow, localNow, fracTime);
                 stbi_write_png(fmt::format("{}", screenshotPath).c_str(), screen.width, screen.height, 4,
                                screen.framebuffers[1].data(), screen.width * sizeof(uint32));
                 m_context.DisplayMessage(fmt::format("Screenshot saved to {}", screenshotPath));


### PR DESCRIPTION
ISO 8601 is a standard timestamp-format that has a millisecond resolution variant as well. https://en.wikipedia.org/wiki/ISO_8601

The `Z` specifier is not used since this is strictly local time and not UTC.