### PR TITLE
FreeBSD CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,6 +174,54 @@ jobs:
       - name: Build
         run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --parallel
 
+  build-freebsd-x64:
+    name: freebsd-x64
+    runs-on: ubuntu-latest
+    # strategy:
+    #   matrix:
+    #     architecture: [ arm64, x86-64 ]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set reusable strings
+        id: strings
+        shell: bash
+        run: |
+          echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+      - uses: cross-platform-actions/action@v0.29.0
+        with:
+          operating_system: freebsd
+          # architecture: ${{ matrix.architecture }}
+          architecture: x86-64
+          version: '14.3'
+          run: |
+            sudo pkg upgrade -y
+            sudo pkg install -y cmake evdev-proto libX11 libXcursor libXext libXfixes \
+              libXi libXrandr libXrender libXScrnSaver libglvnd libinotify llvm19 \
+              ninja pkgconf vulkan-loader
+
+            cmake -B ${{ steps.strings.outputs.build-output-dir }} \
+              -DCMAKE_CXX_COMPILER=clang++19 \
+              -DCMAKE_CXX_FLAGS=-I/usr/local/include \
+              -DCMAKE_C_COMPILER=clang19 \
+              -DCMAKE_C_FLAGS=-I/usr/local/include \
+              -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/lib \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DBUILD_SHARED_LIBS=OFF \
+              -DYmir_ENABLE_DEVLOG=OFF \
+              -DYmir_ENABLE_IMGUI_DEMO=OFF \
+              -DYmir_ENABLE_SANDBOX=OFF \
+              -DYmir_ENABLE_YMDASM=ON \
+              -DYmir_ENABLE_IPO=OFF \
+              -S ${{ github.workspace }} \
+              -G Ninja
+
+            cmake --build ${{ steps.strings.outputs.build-output-dir }} --parallel
+
   build-macos:
     name: macos-${{ matrix.arch.name }}
     runs-on: macos-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
           -DYmir_ENABLE_IMGUI_DEMO=OFF
           -DYmir_ENABLE_SANDBOX=OFF
           -DYmir_ENABLE_YMDASM=ON
-          -DYmir_ENABLE_LTO=OFF
+          -DYmir_ENABLE_IPO=OFF
           -S ${{ github.workspace }}
           -G Ninja
 
@@ -73,7 +73,7 @@ jobs:
   #         -DYmir_ENABLE_IMGUI_DEMO=OFF
   #         -DYmir_ENABLE_SANDBOX=OFF
   #         -DYmir_ENABLE_YMDASM=ON
-  #         -DYmir_ENABLE_LTO=OFF
+  #         -DYmir_ENABLE_IPO=OFF
   #         -S ${{ github.workspace }}
   #         -G Ninja
 
@@ -120,7 +120,7 @@ jobs:
           -DYmir_ENABLE_IMGUI_DEMO=OFF
           -DYmir_ENABLE_SANDBOX=OFF
           -DYmir_ENABLE_YMDASM=ON
-          -DYmir_ENABLE_LTO=OFF
+          -DYmir_ENABLE_IPO=OFF
           -S ${{ github.workspace }}
           -G Ninja
 
@@ -167,7 +167,7 @@ jobs:
           -DYmir_ENABLE_IMGUI_DEMO=OFF
           -DYmir_ENABLE_SANDBOX=OFF
           -DYmir_ENABLE_YMDASM=ON
-          -DYmir_ENABLE_LTO=OFF
+          -DYmir_ENABLE_IPO=OFF
           -S ${{ github.workspace }}
           -G Ninja
 
@@ -255,7 +255,7 @@ jobs:
           -DYmir_ENABLE_IMGUI_DEMO=OFF
           -DYmir_ENABLE_SANDBOX=OFF
           -DYmir_ENABLE_YMDASM=ON
-          -DYmir_ENABLE_LTO=OFF
+          -DYmir_ENABLE_IPO=OFF
           -S ${{ github.workspace }}
           -G Ninja
 

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -75,7 +75,8 @@ cmake --build build --parallel
 To build Ymir on FreeBSD, first you will need to install SDL3's required dependencies:
 
 ```sh
-pkg install libX11 libXext libXrandr libXrender libglvnd
+pkg install evdev-proto libX11 libXcursor libXext libXfixes libXi libXrandr libXrender \
+    libXScrnSaver libglvnd libinotify pkgconf vulkan-loader
 ```
 
 The compiler of choice for this platform is Clang. Although a Clang compiler toolchain
@@ -83,7 +84,7 @@ is provided with a base install of FreeBSD, it lacks the required `clang-scan-de
 binary. It is required to install a complete LLVM toolchain:
 
 ```sh
-pkg install llvm
+pkg install llvm19
 ```
 
 Finally, install CMake. Compiling with Ninja is generally recommended:
@@ -93,13 +94,17 @@ pkg install cmake ninja
 ```
 
 Use CMake to generate a Makefile or (preferably) a Ninja build script. It is necessary
-to tell CMake to use the correct compiler from the previous LLVM installation. The
-`llvm` package is a meta-package which installs a specific version. For example, if
-it installs `llvm19`, then use `clang19` and `clang++19`. It is also recommended to
-add the paths `/usr/local/include` and `/usr/local/lib` to the build environment:
+to tell CMake to use the correct compiler from the previous LLVM installation. It
+is also recommended to add the paths `/usr/local/include` and `/usr/local/lib` to
+the build environment:
 
 ```sh
-cmake -S . -B build -G Ninja -DCMAKE_C_COMPILER="clang19" -DCMAKE_CXX_COMPILER="clang++19" -DCMAKE_C_FLAGS="/usr/local/include" -DCMAKE_CXX_FLAGS="/usr/local/include" -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/lib"
+cmake -S . -B build -G Ninja \
+    -DCMAKE_CXX_COMPILER=clang++19 \
+    -DCMAKE_CXX_FLAGS=-I/usr/local/include \
+    -DCMAKE_C_COMPILER=clang19 \
+    -DCMAKE_C_FLAGS=-I/usr/local/include \
+    -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/lib
 ```
 
 Pass additional `-D<option>=<value>` parameters to tune the build. See the [Build configuration](#build-configuration) section above for details.


### PR DESCRIPTION
Added FreeBSD x64 to CI and updated COMPILING to be more consistent with the CI.

Arm64 throws the following errors:
```
In file included from /home/runner/work/Ymir/Ymir/apps/ymir-sdl3/src/app/stb_implementations.cpp:4:
/home/runner/work/Ymir/Ymir/vendor/stb/stb/stb_image_write.h:354:59: error: non-const lvalue reference to type '__builtin_va_list' cannot bind to a value of unrelated type 'va_list' (aka 'std::__va_list')
  354 |          case '1': { unsigned char x = STBIW_UCHAR(va_arg(v, int));
      |                                                           ^
/usr/local/llvm19/lib/clang/19/include/__stdarg_va_arg.h:20:43: note: expanded from macro 'va_arg'
   20 | #define va_arg(ap, type) __builtin_va_arg(ap, type)
      |                                           ^~
/home/runner/work/Ymir/Ymir/vendor/stb/stb/stb_image_write.h:248:42: note: expanded from macro 'STBIW_UCHAR'
  248 | #define STBIW_UCHAR(x) (unsigned char) ((x) & 0xff)
      |                                          ^
```
I currently don't know what's the cause for this error, seems something specific to FreeBSD arm64 and maybe even the compiler. Because I don't have a arm64 system to debug and test, I excluded this architecture from CI for now.

While there, fixed the (intended) Ymir_ENABLE_IPO usage in the CI.