### PR TITLE
feat(app): Automatically detect profile path and allow using the user profile path from the OS

### DIFF
--- a/apps/ymir-sdl3/src/app/cmdline_opts.hpp
+++ b/apps/ymir-sdl3/src/app/cmdline_opts.hpp
@@ -7,6 +7,7 @@ namespace app {
 struct CommandLineOptions {
     std::filesystem::path gameDiscPath;
     std::filesystem::path profilePath;
+    bool forceUserProfile;
     bool fullScreen;
     bool startPaused;
 };

--- a/apps/ymir-sdl3/src/app/settings.cpp
+++ b/apps/ymir-sdl3/src/app/settings.cpp
@@ -1166,7 +1166,7 @@ SettingsLoadResult Settings::Load(const std::filesystem::path &path) {
 
 SettingsSaveResult Settings::Save() {
     if (path.empty()) {
-        path = "Ymir.toml";
+        path = kSettingsFile;
     }
 
     // clang-format off
@@ -1214,7 +1214,7 @@ SettingsSaveResult Settings::Save() {
             {"EmulateSH2Cache", system.emulateSH2Cache},
             {"InternalBackupRAMImagePath", Proximate(ProfilePath::PersistentState, system.internalBackupRAMImagePath).native()},
             {"InternalBackupRAMPerGame", system.internalBackupRAMPerGame},
-        
+
             {"IPL", toml::table{{
                 {"Override", system.ipl.overrideImage},
                 {"Path", Proximate(ProfilePath::IPLROMImages, system.ipl.path).native()},
@@ -1240,7 +1240,7 @@ SettingsSaveResult Settings::Save() {
             {"PreviousFrameRateOSDPosition", ToTOML(hotkeys.prevFrameRateOSDPos)},
             {"RotateScreenClockwise", ToTOML(hotkeys.rotateScreenCW)},
             {"RotateScreenCounterclockwise", ToTOML(hotkeys.rotateScreenCCW)},
-            
+
             {"ToggleMute", ToTOML(hotkeys.toggleMute)},
             {"IncreaseVolume", ToTOML(hotkeys.increaseVolume)},
             {"DecreaseVolume", ToTOML(hotkeys.decreaseVolume)},

--- a/apps/ymir-sdl3/src/app/settings.hpp
+++ b/apps/ymir-sdl3/src/app/settings.hpp
@@ -31,6 +31,8 @@
 
 namespace app {
 
+inline constexpr std::string_view kSettingsFile = "Ymir.toml";
+
 struct SettingsLoadResult {
     enum class Type { Success, TOMLParseError, UnsupportedConfigVersion };
 

--- a/apps/ymir-sdl3/src/main.cpp
+++ b/apps/ymir-sdl3/src/main.cpp
@@ -16,6 +16,7 @@ int main(int argc, char **argv) {
     options.add_options()("d,disc", "Path to Saturn disc image (.ccd, .chd, .cue, .iso, .mds)",
                           cxxopts::value(progOpts.gameDiscPath));
     options.add_options()("p,profile", "Path to profile directory", cxxopts::value(progOpts.profilePath));
+    options.add_options()("u,user", "Force user profile", cxxopts::value(progOpts.forceUserProfile)->default_value("false"));
     options.add_options()("h,help", "Display help text", cxxopts::value(showHelp)->default_value("false"));
     options.add_options()("f,fullscreen", "Start in fullscreen mode",
                           cxxopts::value(progOpts.fullScreen)->default_value("false"));


### PR DESCRIPTION
Ymir tries to detect the profile path by locating Ymir.toml in the portable path first and then in the user's home directory. If it can't locate Ymir.toml in one of these directories, it will show a dialog on startup, in which the desired profile mode can be selected. "Installed" mode uses the user's home directory and "Portable" mode uses the portable path, i.e. the current working directory.

Specifying the -p option still overrides this behavior and uses the given custom profile path.

A new option -u is available which forces usage of the user's home directory and which overrides all other behavior.

Contains additional cosmetic code changes:
* put the profile selection code closer to where the settings file is loaded
* replace multiple occurrences of string literal "Ymir.toml" with a constant
* trim some trailing whitespaces

Fixes #17 