### PR TITLE
fix (build): Use localtime_s on Windows ARM64

### DIFF
--- a/apps/ymir-sdl3/src/util/std_lib.cpp
+++ b/apps/ymir-sdl3/src/util/std_lib.cpp
@@ -5,7 +5,7 @@ namespace util {
 tm to_local_time(std::chrono::system_clock::time_point tp) {
     const time_t time = std::chrono::system_clock::to_time_t(tp);
     tm tm;
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(_M_ARM64)
     void(localtime_s(&tm, &time));
 #elif defined(__GNUC__)
     localtime_r(&time, &tm);


### PR DESCRIPTION
This adds the _M_ARM64 check to address build failure when using MSYS2 environment on Windows ARM64