### PR TITLE
build: add win arm64 ci support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
 
   build-windows:
     name: windows-${{ matrix.c_compiler }}-${{ matrix.architecture.name }}
-    runs-on: windows-2025
+    runs-on: ${{ matrix.architecture.runner }}
     needs: [get-project-version]
 
     strategy:
@@ -53,8 +53,16 @@ jobs:
         architecture:
           - name: "x86_64-SSE2"
             enable_avx2_option: "OFF"
+            runner: windows-latest
+            target: x64
           - name: "x86_64-AVX2"
             enable_avx2_option: "ON"
+            runner: windows-latest
+            target: x64
+          - name: "ARM64"
+            enable_avx2_option: "OFF"
+            runner: windows-11-arm
+            target: arm64         
         include:
           - c_compiler: clang
             cpp_compiler: clang
@@ -79,7 +87,7 @@ jobs:
         if: ${{ matrix.c_compiler == 'cl' }}
         uses: TheMrMilchmann/setup-msvc-dev@v3
         with:
-          arch: x64
+         arch: ${{ matrix.architecture.target }}
 
       - name: Configure CMake
         run: >

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,42 +43,38 @@ jobs:
       - name: Build
         run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --parallel
 
-  # build-windows-a64:
-  #   name: windows-a64
-  #   # runs-on: windows-11-arm
-  #   runs-on: windows-latest
+  build-windows-a64:
+    name: windows-a64
+    runs-on: windows-11-arm
 
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-  #     - name: Set reusable strings
-  #       id: strings
-  #       shell: bash
-  #       run: |
-  #         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+      - name: Set reusable strings
+        id: strings
+        shell: bash
+        run: |
+          echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
-  #     - name: Configure CMake
-  #       run: >
-  #         cmake -B ${{ steps.strings.outputs.build-output-dir }}
-  #         -DCMAKE_CXX_COMPILER="C:\Program Files\LLVM\bin\clang++.exe"
-  #         -DCMAKE_C_COMPILER="C:\Program Files\LLVM\bin\clang.exe"
-  #         -DCMAKE_LINKER="C:\Program Files\LLVM\bin\lld-link.exe"
-  #         -DCMAKE_CXX_FLAGS="--target=arm64-pc-windows-gnullvm"
-  #         -DCMAKE_C_FLAGS="--target=arm64-pc-windows-gnullvm"
-  #         -DCMAKE_BUILD_TYPE=Debug
-  #         -DBUILD_SHARED_LIBS=OFF
-  #         -DYmir_ENABLE_DEVLOG=OFF
-  #         -DYmir_ENABLE_IMGUI_DEMO=OFF
-  #         -DYmir_ENABLE_SANDBOX=OFF
-  #         -DYmir_ENABLE_YMDASM=ON
-  #         -DYmir_ENABLE_IPO=OFF
-  #         -S ${{ github.workspace }}
-  #         -G Ninja
+      - name: Configure CMake
+        run: >
+          cmake -B ${{ steps.strings.outputs.build-output-dir }}
+          -DCMAKE_CXX_COMPILER=clang++
+          -DCMAKE_C_COMPILER=clang
+          -DCMAKE_BUILD_TYPE=Debug
+          -DBUILD_SHARED_LIBS=OFF
+          -DYmir_ENABLE_DEVLOG=OFF
+          -DYmir_ENABLE_IMGUI_DEMO=OFF
+          -DYmir_ENABLE_SANDBOX=OFF
+          -DYmir_ENABLE_YMDASM=ON
+          -DYmir_ENABLE_IPO=OFF
+          -S ${{ github.workspace }}
+          -G Ninja
 
-  #     - name: Build
-  #       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --parallel
+      - name: Build
+        run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --parallel
 
   build-linux-x64:
     name: linux-x64


### PR DESCRIPTION
This PR adds in Windows ARM64 builds using windows-11-arm runner.

The changes were tested on a separate branch here: https://github.com/tordona/Ymir/tree/refs/heads/ci-test-stub

The output binaries, and locally built binaries were tested on physical hardware listed below

**Test Devices**
| Device | CPU |
| -------- | ------- |
| Microsoft Surface Pro X  | Microsoft SQ2 |
| Dell Inspiron 3420 | Snapdragon 8cx Gen 2 |
| Lenovo ThinkPad x13s | Snapdragon 8cx Gen 3 |
| Lenovo IdeaPad 5x | Snapdragon X Plus X1P-42-100 |
