### PR TITLE
build: Revert to quarterly branch in FreeBSD CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -195,8 +195,6 @@ jobs:
           architecture: x86-64
           version: '14.3'
           run: |
-            sudo mkdir -p /usr/local/etc/pkg/repos
-            echo 'FreeBSD: { url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest" }' | sudo tee /usr/local/etc/pkg/repos/FreeBSD.conf
             sudo pkg upgrade -y
             sudo pkg install -y cmake evdev-proto libX11 libXcursor libXext libXfixes \
               libXi libXrandr libXrender libXScrnSaver libglvnd libinotify llvm21 \


### PR DESCRIPTION
llvm21 is now available in the quarterly package repository, so the CI can revert to using the more stable quarterly branch instead of the rolling-release latest branch.