### PR TITLE
feat(build): Add Arm Windows cmake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -150,6 +150,75 @@
       }
     },
     {
+      "name": "a64-Clang-Debug",
+      "displayName": "a64 Clang Debug",
+      "description": "Sets Ninja generator, Clang-CL compiler, a64 architecture, build and install directory, debug build type",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "architecture": {
+        "value": "arm64",
+        "strategy": "external"
+      },
+      "toolset": "ClangCL",
+      "environment": {
+        "CC": "clang-cl",
+        "CXX": "clang-cl"
+      },
+      "toolchainFile": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "arm64-windows-static-md",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+        "Ymir_ENABLE_IPO": "OFF",
+        "Ymir_ENABLE_DEV_ASSERTIONS": "ON",
+        "Ymir_AVX2": "OFF",
+        "Ymir_ENABLE_UPDATE_CHECKS": "ON"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [
+            "Windows"
+          ],
+          "intelliSenseMode": "windows-clang-arm64"
+        }
+      }
+    },
+    {
+      "name": "a64-Clang-Release",
+      "displayName": "a64 Clang Release",
+      "description": "Sets Ninja generator, Clang-CL compiler, a64 architecture, build and install directory, release build type",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "architecture": {
+        "value": "arm64",
+        "strategy": "external"
+      },
+      "toolset": "ClangCL",
+      "environment": {
+        "CC": "clang-cl",
+        "CXX": "clang-cl"
+      },
+      "toolchainFile": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "arm64-windows-static-md",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+        "Ymir_ENABLE_IPO": "OFF",
+        "Ymir_ENABLE_DEV_ASSERTIONS": "ON",
+        "Ymir_EXTRA_INLINING": "OFF",
+        "Ymir_AVX2": "OFF",
+        "Ymir_ENABLE_UPDATE_CHECKS": "ON"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [
+            "Windows"
+          ],
+          "intelliSenseMode": "windows-clang-arm64"
+        }
+      }
+    },
+    {
       "name": "x64-MSVC-Debug",
       "displayName": "x64 MSVC Debug",
       "description": "Sets Ninja generator, MSVC compiler, x64 architecture, build and install directory, debug build type",


### PR DESCRIPTION
Adds Cmake presets for Windows on Arm development for Visual Studio to pick up to facilitate development on this platform. This is enough to get debug/release builds going with breakpoints and such, but intellisense is still kinda weird.
Likely due to the lack of an `arm64-win-llvm` vcpkg-triplet. For now, the `arm64-windows-static-md` triplet is used.

A proper `arm64-win-llvm-*` toolchain will be implemented in another PR.