### PR TITLE
chore(build): Update v0.2.2 release version in the XDG app descriptor

### DIFF
--- a/apps/ymir-sdl3/res/io.github.strikerx3.ymir.xml
+++ b/apps/ymir-sdl3/res/io.github.strikerx3.ymir.xml
@@ -61,7 +61,7 @@
   <releases>
     <release version="0.2.2" date="20XX-XX-XX">
       <description/>
-      <url>https://github.com/StrikerX3/Ymir/releases/tag/v0.2.1</url>
+      <url>https://github.com/StrikerX3/Ymir/releases/tag/v0.2.2</url>
     </release>
     <release version="0.2.1" date="2026-01-10">
       <description/>


### PR DESCRIPTION
I know this is just small but this is also to inform you flathub is up to date with 0.2.1