### PR TITLE
docs: add core dump instructions for FreeBSD

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -19,7 +19,7 @@ If you're on Windows, follow these steps to collect and share a minidump:
 5. Open the folder from which you ran the command (you can run `start .` from the Command Prompt to open an Explorer window on that directory). There should be a file named `ymir-sdl3.exe_<date>_<time>.dmp`. Compress that and share it. This file contains a minimal dump of the program which can be used by developers to figure out where exactly the emulator crashed.
    - For developers: the PDBs can be found attached to the [nightly release workflow](https://github.com/StrikerX3/Ymir/actions/workflows/nightly-release.yaml).
 
-On Linux or macOS:
+On Linux, macOS or FreeBSD:
 1. Enable core dumps temporarily (if you haven't already enabled them system-wide):
     ```sh
     ulimit -c unlimited
@@ -27,11 +27,11 @@ On Linux or macOS:
 2. Run the emulator from the same shell session.
 3. When the crash occurs, open a new shell and collect the dump:
     1. Find the PID of the process:
-        Linux-only:
+        Linux and FreeBSD:
         ```sh
         pgrep ymir-sdl3
         ```
-        or (Linux or macOS):
+        or (Linux, macOS or FreeBSD):
         ```sh
         ps a | grep ymir-sdl3
         ```
@@ -40,7 +40,11 @@ On Linux or macOS:
         ```sh
         gcore -o ymir.dmp <pid>
         ```
-        or (Linux or macOS):
+        FreeBSD-only:
+        ```sh
+        gcore -c ymir.dmp <pid>
+        ```
+        or (Linux, macOS or FreeBSD):
         ```sh
         kill -6 <PID>
         ```


### PR DESCRIPTION
While the general instructions for Linux and macOS are also applicable to FreeBSD it's worth mentioning that the `gcore` command differs in the option switch `-c` for naming the output file.