### PR TITLE
feat(app): Added setting for preffered IPL ROM via dropdown

### DIFF
--- a/apps/ymir-sdl3/src/app/app.cpp
+++ b/apps/ymir-sdl3/src/app/app.cpp
@@ -4311,7 +4311,7 @@ std::filesystem::path App::GetIPLROMPath() {
         if (firstMatch.empty()) {
             firstMatch = path;
         }
-        if (preferredVariant == ymir::db::SystemVariant::None || info::info->variant == preferredVariant) {
+        if (preferredVariant == ymir::db::SystemVariant::None || info.info->variant == preferredVariant) {
             if (info.info->region == preferredRegion) {
                 devlog::info<grp::base>("Using auto-detected IPL ROM");
                 return path;

--- a/apps/ymir-sdl3/src/app/app.cpp
+++ b/apps/ymir-sdl3/src/app/app.cpp
@@ -4270,8 +4270,7 @@ std::filesystem::path App::GetIPLROMPath() {
 
     // Auto-select ROM from IPL ROM manager based on preferred system variant and area code
 
-    // TODO: make this configurable
-    ymir::db::SystemVariant preferredVariant = ymir::db::SystemVariant::Saturn;
+    ymir::db::SystemVariant preferredVariant = m_context.settings.system.ipl.variant;
 
     // SMPC area codes:
     //   0x1  J  Domestic NTSC        Japan

--- a/apps/ymir-sdl3/src/app/app.cpp
+++ b/apps/ymir-sdl3/src/app/app.cpp
@@ -4302,6 +4302,7 @@ std::filesystem::path App::GetIPLROMPath() {
     // Try to find exact match
     // Keep a region-free fallback in case there isn't a perfect match
     std::filesystem::path regionFreeMatch = "";
+    std::filesystem::path variantMatch = "";
     std::filesystem::path firstMatch = "";
     for (auto &[path, info] : m_context.romManager.GetIPLROMs()) {
         if (info.info == nullptr) {
@@ -4310,12 +4311,12 @@ std::filesystem::path App::GetIPLROMPath() {
         if (firstMatch.empty()) {
             firstMatch = path;
         }
-        if (info.info->variant == preferredVariant) {
+        if (preferredVariant == ymir::db::SystemVariant::None || info::info->variant == preferredVariant) {
             if (info.info->region == preferredRegion) {
                 devlog::info<grp::base>("Using auto-detected IPL ROM");
                 return path;
-            } else if (info.info->region == ymir::db::SystemRegion::RegionFree && regionFreeMatch.empty()) {
-                regionFreeMatch = path;
+            } else {
+                variantMatch = path;
             }
         }
     }
@@ -4326,8 +4327,12 @@ std::filesystem::path App::GetIPLROMPath() {
         devlog::info<grp::base>("Using auto-detected region-free IPL ROM");
         return regionFreeMatch;
     }
-
-    // Return whatever is available
+    
+    //Fallback top variant match if found
+    if(!variantMatch.empty()){
+        devlog::info<grp::base>("Using auto-detected variant IPL ROM with mismatched region");
+        return variantMatch;
+    }
     return firstMatch;
 }
 

--- a/apps/ymir-sdl3/src/app/ui/views/settings/ipl_settings_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/settings/ipl_settings_view.cpp
@@ -211,7 +211,8 @@ void IPLSettingsView::Display() {
 
     ImGui::Separator();
 
-    ImGui::TextUnformatted("Preferred System Variant");
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Preferred system variant");
     ImGui::SameLine();
     const char* variants[] = {"Saturn", "Hi-Saturn", "V-Saturn", "Dev Kit"};
     int currentVariant = static_cast<int>(settings.variant) - 1;

--- a/apps/ymir-sdl3/src/app/ui/views/settings/ipl_settings_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/settings/ipl_settings_view.cpp
@@ -214,13 +214,15 @@ void IPLSettingsView::Display() {
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Preferred system variant");
     ImGui::SameLine();
-    const char* variants[] = {"Saturn", "Hi-Saturn", "V-Saturn", "Dev Kit"};
-    int currentVariant = static_cast<int>(settings.variant) - 1;
-    if (currentVariant < 0) currentVariant = 0;
-    if (ImGui::Combo("##variant", &currentVariant, variants, 4)) {
-        settings.variant = static_cast<db::SystemVariant>(currentVariant + 1);
-        m_context.EnqueueEvent(events::gui::ReloadIPLROM());
-        m_context.settings.MakeDirty();
+    if (ImGui::BeginCombo("##variant", GetVariantName(settings.variant), ImGuiComboFlags_WidthFitPreview)) {
+        for (int i = 0; i <= 4; ++i) {
+            const auto variant = static_cast<db::SystemVariant>(i);
+            if (MakeDirty(ImGui::Selectable(GetVariantName(variant), variant == settings.variant))) {
+                settings.variant = variant;
+                m_context.EnqueueEvent(events::gui::ReloadIPLROM());
+            }
+        }
+        ImGui::EndCombo();
     }
 
     ImGui::Separator();

--- a/apps/ymir-sdl3/src/app/ui/views/settings/ipl_settings_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/settings/ipl_settings_view.cpp
@@ -211,6 +211,19 @@ void IPLSettingsView::Display() {
 
     ImGui::Separator();
 
+    ImGui::TextUnformatted("Preferred System Variant");
+    ImGui::SameLine();
+    const char* variants[] = {"Saturn", "Hi-Saturn", "V-Saturn", "Dev Kit"};
+    int currentVariant = static_cast<int>(settings.variant) - 1;
+    if (currentVariant < 0) currentVariant = 0;
+    if (ImGui::Combo("##variant", &currentVariant, variants, 4)) {
+        settings.variant = static_cast<db::SystemVariant>(currentVariant + 1);
+        m_context.EnqueueEvent(events::gui::ReloadIPLROM());
+        m_context.settings.MakeDirty();
+    }
+
+    ImGui::Separator();
+
     if (MakeDirty(ImGui::Checkbox("Override IPL ROM", &settings.overrideImage))) {
         if (settings.overrideImage && !settings.path.empty()) {
             m_context.EnqueueEvent(events::gui::ReloadIPLROM());


### PR DESCRIPTION
Motivation:In Issue #637 ,[thelastangryman1907](https://github.com/thelastangryman1907) suggested that allow user to select a variant of Saturn and have the program automatically load the appropriate BIOS. I have little to zero knowledge on how the core system works, so I thought its a good idea to start from something simple like modifying frontend.

I made prefferedVariant variable on app.cpp configurable, and also add ImGui lines to configure which BIOS variant you prefer.

It's also worth mentioning that it's currently only runs properly on Japan region, not other region
Probably has to do with my implementation?

Note:This is my first PR on this program, so let me know if there's some flaws I made, or some changes I need to apply.