### PR TITLE
feat(app)(Re):Add undo feature for save and load states with hotkeys and UI support

### DIFF
--- a/apps/ymir-sdl3/src/app/actions.hpp
+++ b/apps/ymir-sdl3/src/app/actions.hpp
@@ -131,8 +131,8 @@ namespace save_states {
         }
     }
 
-    inline constexpr auto UndoSaveState = input::Action::Trigger(0x003040, "Save states", "Undo save state");
-    inline constexpr auto UndoLoadState = input::Action::Trigger(0x003041, "Save states", "Undo load state");
+    DEF_ACTION(UndoSaveState)::Trigger(ACTION_ID, "Save states", "Undo save state");
+    DEF_ACTION(UndoLoadState)::Trigger(ACTION_ID, "Save states", "Undo load state");
 
 } // namespace save_states
 

--- a/apps/ymir-sdl3/src/app/actions.hpp
+++ b/apps/ymir-sdl3/src/app/actions.hpp
@@ -131,6 +131,9 @@ namespace save_states {
         }
     }
 
+    inline constexpr auto UndoSaveState = input::Action::Trigger(0x003040, "Save states", "Undo save state");
+    inline constexpr auto UndoLoadState = input::Action::Trigger(0x003041, "Save states", "Undo load state");
+
 } // namespace save_states
 
 namespace sys {

--- a/apps/ymir-sdl3/src/app/app.cpp
+++ b/apps/ymir-sdl3/src/app/app.cpp
@@ -4651,9 +4651,9 @@ void App::PersistSaveState(size_t slot) {
     auto lock = std::unique_lock{saves.SlotMutex(slot)};
 
     // ensure to not dereference empty slots
-    auto slotState = saves.Peek(slot);
-    if (slotState && slotState->get().state) {
-        auto &state = *slotState->get().state;
+    auto *slotState = saves.Peek(slot);
+    if (slotState && slotState->state) {
+        auto &state = *slotState->state;
 
         // Create directory for this game's save states
         auto basePath = m_context.profile.GetPath(ProfilePath::SaveStates);

--- a/apps/ymir-sdl3/src/app/app.cpp
+++ b/apps/ymir-sdl3/src/app/app.cpp
@@ -1134,6 +1134,14 @@ void App::RunEmulator() {
                                        [&](void *, const input::InputElement &) { SaveSaveStateSlot(8); });
         inputContext.SetTriggerHandler(actions::save_states::SaveState10,
                                        [&](void *, const input::InputElement &) { SaveSaveStateSlot(9); });
+
+        // Undo save/load state
+        inputContext.SetTriggerHandler(actions::save_states::UndoSaveState, [&](void *, const input::InputElement &) {
+            m_context.EnqueueEvent(events::emu::UndoSaveState());
+        });
+        inputContext.SetTriggerHandler(actions::save_states::UndoLoadState, [&](void *, const input::InputElement &) {
+            m_context.EnqueueEvent(events::emu::UndoLoadState());
+        });
     }
 
     // System
@@ -2473,6 +2481,21 @@ void App::RunEmulator() {
                         ImGui::Separator();
                         drawCommonSaveStatesSection();
                         ImGui::EndMenu();
+                    }
+                    {
+                        auto &saves = m_context.serviceLocator.GetRequired<services::SaveStateService>();
+                        if (ImGui::MenuItem(
+                                "Undo save state",
+                                input::ToShortcut(inputContext, actions::save_states::UndoSaveState).c_str(),
+                                false, saves.CanUndoSave())) {
+                            m_context.EnqueueEvent(events::emu::UndoSaveState());
+                        }
+                    }
+                    if (ImGui::MenuItem(
+                            "Undo load state",
+                            input::ToShortcut(inputContext, actions::save_states::UndoLoadState).c_str(),
+                            false, m_context.canUndoLoad)) {
+                        m_context.EnqueueEvent(events::emu::UndoLoadState());
                     }
                     if (ImGui::MenuItem("Open save states directory")) {
                         auto path = m_context.profile.GetPath(ProfilePath::SaveStates) /

--- a/apps/ymir-sdl3/src/app/events/emu_event_factory.cpp
+++ b/apps/ymir-sdl3/src/app/events/emu_event_factory.cpp
@@ -689,6 +689,13 @@ EmuEvent LoadState(uint32 slot) {
 
         // At this point the ROMs have been loaded and validated
 
+        // Cache current emulator state for undo before loading
+        if (!ctx.undoLoadState) {
+            ctx.undoLoadState = std::make_unique<state::State>();
+        }
+        ctx.saturn.instance->SaveState(*ctx.undoLoadState);
+        ctx.canUndoLoad = true;
+
         if (ctx.saturn.instance->LoadState(state, true)) {
             // Now that the save state has been succesfully loaded, load the ROMs
             if (iplROMData) {
@@ -705,6 +712,8 @@ EmuEvent LoadState(uint32 slot) {
             ctx.EnqueueEvent(events::gui::StateLoaded(slot));
         } else {
             devlog::warn<grp::base>("Failed to load save state");
+            // Clear undo state since load failed
+            ctx.canUndoLoad = false;
         }
     });
 }
@@ -724,9 +733,16 @@ EmuEvent SaveState(uint32 slot) {
 
             // build new state logically
             // test if state is present and either clone or create a new one
+            // Cache existing state for undo before overwriting
             auto savePtr = saves.Peek(slot);
-            slotState.state = savePtr && savePtr->get().state ? std::make_unique<state::State>(*savePtr->get().state)
-                                                              : std::make_unique<state::State>();
+            if (savePtr && savePtr->get().state) {
+                // Move current state to undo storage
+                slotState.undoState = std::make_unique<state::State>(*savePtr->get().state);
+                slotState.undoTimestamp = savePtr->get().timestamp;
+            }
+
+            // build new state
+            slotState.state = std::make_unique<state::State>();
 
             // save state to selected slot and set timestamp
             ctx.saturn.instance->SaveState(*slotState.state);
@@ -737,9 +753,49 @@ EmuEvent SaveState(uint32 slot) {
                 devlog::warn<grp::base>("Could not set/save new save state for slot {}", slot);
                 return;
             }
+
+            // Track which slot was last saved for undo
+            saves.SetLastSavedSlot(slot);
         }
 
         ctx.EnqueueEvent(events::gui::StateSaved(slot));
+    });
+}
+
+EmuEvent UndoSaveState() {
+    return RunFunction([](SharedContext &ctx) {
+        auto &saves = ctx.serviceLocator.GetRequired<services::SaveStateService>();
+        
+        auto lastSlot = saves.GetLastSavedSlot();
+        if (!lastSlot.has_value()) {
+            ctx.DisplayMessage("No save state to undo");
+            return;
+        }
+
+        auto slot = *lastSlot;
+        auto lock = std::unique_lock{saves.SlotMutex(slot)};
+        if (saves.UndoSave(slot)) {
+            ctx.DisplayMessage(fmt::format("Undid save state in slot {}", slot + 1));
+            ctx.EnqueueEvent(events::gui::StateSaved(static_cast<uint32>(slot)));
+        } else {
+            ctx.DisplayMessage("No save state to undo");
+        }
+    });
+}
+
+EmuEvent UndoLoadState() {
+    return RunFunction([](SharedContext &ctx) {
+        if (!ctx.canUndoLoad || !ctx.undoLoadState) {
+            ctx.DisplayMessage("No load state to undo");
+            return;
+        }
+
+        if (ctx.saturn.instance->LoadState(*ctx.undoLoadState, true)) {
+            ctx.DisplayMessage("Undid load state");
+            ctx.canUndoLoad = false;
+        } else {
+            devlog::warn<grp::base>("Failed to undo load state");
+        }
     });
 }
 

--- a/apps/ymir-sdl3/src/app/events/emu_event_factory.hpp
+++ b/apps/ymir-sdl3/src/app/events/emu_event_factory.hpp
@@ -129,5 +129,7 @@ EmuEvent SetSCSPStepGranularity(uint32 granularity);
 
 EmuEvent LoadState(uint32 slot);
 EmuEvent SaveState(uint32 slot);
+EmuEvent UndoSaveState();
+EmuEvent UndoLoadState();
 
 } // namespace app::events::emu

--- a/apps/ymir-sdl3/src/app/services/savestates/save_state_service.cpp
+++ b/apps/ymir-sdl3/src/app/services/savestates/save_state_service.cpp
@@ -18,15 +18,15 @@ using namespace app::savestates;
 
 namespace app::services {
 
-std::optional<std::reference_wrapper<const SaveState>> SaveStateService::Peek(std::size_t slot) const noexcept {
+SaveState *SaveStateService::Peek(std::size_t slot) noexcept {
     if (!InRange(slot, m_slots_.size())) {
-        return std::nullopt;
+        return nullptr;
     }
     if (!m_slots_[slot].state) {
-        return std::nullopt;
+        return nullptr;
     }
 
-    return std::cref(m_slots_[slot]);
+    return &m_slots_[slot];
 }
 
 bool SaveStateService::Set(std::size_t slot, SaveState &&s) {

--- a/apps/ymir-sdl3/src/app/services/savestates/save_state_service.cpp
+++ b/apps/ymir-sdl3/src/app/services/savestates/save_state_service.cpp
@@ -67,4 +67,41 @@ void SaveStateService::SetCurrentSlot(std::size_t slot) noexcept {
     return m_saveStateLocks_[slot];
 }
 
+bool SaveStateService::CanUndoSave(std::size_t slot) const noexcept {
+    if (!InRange(slot, m_slots_.size())) {
+        return false;
+    }
+    return m_slots_[slot].undoState != nullptr;
+}
+
+bool SaveStateService::CanUndoSave() const noexcept {
+    if (!m_lastSavedSlot_.has_value()) {
+        return false;
+    }
+    return CanUndoSave(*m_lastSavedSlot_);
+}
+
+bool SaveStateService::UndoSave(std::size_t slot) {
+    if (!CanUndoSave(slot)) {
+        return false;
+    }
+    // Swap current state with undo state
+    std::swap(m_slots_[slot].state, m_slots_[slot].undoState);
+    std::swap(m_slots_[slot].timestamp, m_slots_[slot].undoTimestamp);
+    // Clear undo after use
+    m_slots_[slot].undoState.reset();
+    m_lastSavedSlot_.reset();
+    return true;
+}
+
+std::optional<std::size_t> SaveStateService::GetLastSavedSlot() const noexcept {
+    return m_lastSavedSlot_;
+}
+
+void SaveStateService::SetLastSavedSlot(std::size_t slot) noexcept {
+    if (InRange(slot, m_slots_.size())) {
+        m_lastSavedSlot_ = slot;
+    }
+}
+
 } // namespace app::services

--- a/apps/ymir-sdl3/src/app/services/savestates/save_state_service.hpp
+++ b/apps/ymir-sdl3/src/app/services/savestates/save_state_service.hpp
@@ -24,11 +24,9 @@ public:
         return m_slots_.size();
     }
 
-    // read-only slot access w/o remove or copy
-    // we wrap a const reference to avoid copying
-    // unique ptr contents
-    [[nodiscard]] std::optional<std::reference_wrapper<const savestates::SaveState>>
-    Peek(std::size_t slot) const noexcept;
+    // slot access returning mutable pointer for efficient state operations
+    // returns nullptr when slot is empty or out of range
+    [[nodiscard]] savestates::SaveState *Peek(std::size_t slot) noexcept;
 
     // mutators (replace/update slot explicitly)
     bool Set(std::size_t slot, savestates::SaveState &&s);

--- a/apps/ymir-sdl3/src/app/services/savestates/save_state_service.hpp
+++ b/apps/ymir-sdl3/src/app/services/savestates/save_state_service.hpp
@@ -46,9 +46,17 @@ public:
     // controlled access to state locks
     [[nodiscard]] std::mutex &SlotMutex(std::size_t slot) noexcept;
 
+    // Undo save state support
+    [[nodiscard]] bool CanUndoSave(std::size_t slot) const noexcept;
+    [[nodiscard]] bool CanUndoSave() const noexcept; // uses last saved slot
+    bool UndoSave(std::size_t slot);
+    [[nodiscard]] std::optional<std::size_t> GetLastSavedSlot() const noexcept;
+    void SetLastSavedSlot(std::size_t slot) noexcept;
+
 private:
     SlotArray m_slots_{};
     std::size_t m_currentSlot_{0};
+    std::optional<std::size_t> m_lastSavedSlot_{};
     std::array<std::mutex, kSlots> m_saveStateLocks_{};
 };
 

--- a/apps/ymir-sdl3/src/app/services/savestates/types.hpp
+++ b/apps/ymir-sdl3/src/app/services/savestates/types.hpp
@@ -28,6 +28,10 @@ struct SaveState {
     std::unique_ptr<ymir::state::State> state;
     std::chrono::system_clock::time_point timestamp{};
 
+    // Per-slot undo: stores previous state before last overwrite
+    std::unique_ptr<ymir::state::State> undoState;
+    std::chrono::system_clock::time_point undoTimestamp{};
+
     // unique ptr means that a state can be moved or move-created,
     // but cannot and should not be copyable;
     // destructor not inlined

--- a/apps/ymir-sdl3/src/app/settings.cpp
+++ b/apps/ymir-sdl3/src/app/settings.cpp
@@ -545,6 +545,9 @@ Settings::Settings(SharedContext &sharedCtx) noexcept
     mapInput(m_actionInputs, hotkeys.saveStates.save9);
     mapInput(m_actionInputs, hotkeys.saveStates.save10);
 
+    mapInput(m_actionInputs, hotkeys.saveStates.undoSave);
+    mapInput(m_actionInputs, hotkeys.saveStates.undoLoad);
+
     // Saturn Control Pad
     auto mapControlPad = [&](InputMap &inputMap, Input::Port::ControlPad::Binds &binds) {
         mapInput(inputMap, binds.a);
@@ -972,6 +975,9 @@ SettingsLoadResult Settings::Load(const std::filesystem::path &path) {
             Parse(tblSaveStates, "SaveState8", hotkeys.saveStates.save8);
             Parse(tblSaveStates, "SaveState9", hotkeys.saveStates.save9);
             Parse(tblSaveStates, "SaveState10", hotkeys.saveStates.save10);
+
+            Parse(tblSaveStates, "UndoSaveState", hotkeys.saveStates.undoSave);
+            Parse(tblSaveStates, "UndoLoadState", hotkeys.saveStates.undoLoad);
         }
     }
 
@@ -1437,6 +1443,9 @@ SettingsSaveResult Settings::Save() {
                 {"SaveState8", ToTOML(hotkeys.saveStates.save8)},
                 {"SaveState9", ToTOML(hotkeys.saveStates.save9)},
                 {"SaveState10", ToTOML(hotkeys.saveStates.save10)},
+
+                {"UndoSaveState", ToTOML(hotkeys.saveStates.undoSave)},
+                {"UndoLoadState", ToTOML(hotkeys.saveStates.undoLoad)},
             }}},
         }}},
 

--- a/apps/ymir-sdl3/src/app/settings.hpp
+++ b/apps/ymir-sdl3/src/app/settings.hpp
@@ -276,6 +276,9 @@ struct Settings {
             input::InputBind save8{actions::save_states::SaveState8};
             input::InputBind save9{actions::save_states::SaveState9};
             input::InputBind save10{actions::save_states::SaveState10};
+
+            input::InputBind undoSave{actions::save_states::UndoSaveState};
+            input::InputBind undoLoad{actions::save_states::UndoLoadState};
         } saveStates;
     } hotkeys;
 

--- a/apps/ymir-sdl3/src/app/shared_context.hpp
+++ b/apps/ymir-sdl3/src/app/shared_context.hpp
@@ -488,6 +488,10 @@ struct SharedContext {
     RewindBuffer rewindBuffer;
     bool rewinding = false;
 
+    // Undo load state support - stores the emulator state before loading
+    std::unique_ptr<ymir::state::State> undoLoadState{};
+    bool canUndoLoad = false;
+
     struct Midi {
         std::unique_ptr<RtMidiIn> midiInput;
         std::unique_ptr<RtMidiOut> midiOutput;

--- a/apps/ymir-sdl3/src/app/ui/views/settings/hotkeys_settings_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/settings/hotkeys_settings_view.cpp
@@ -123,6 +123,9 @@ void HotkeysSettingsView::Display() {
         drawRow(hotkeys.saveStates.save9);
         drawRow(hotkeys.saveStates.save10);
 
+        drawRow(hotkeys.saveStates.undoSave);
+        drawRow(hotkeys.saveStates.undoLoad);
+
         m_inputCaptureWidget.DrawCapturePopup();
 
         ImGui::EndTable();


### PR DESCRIPTION
Note:this is an updated ver of Pull Request #726 , supporting new architecture with ServiceLocator.

Motivation:Similar to previous PR, in Issue https://github.com/StrikerX3/Ymir/issues/700 ,[butthead-acdc](https://github.com/butthead-acdc) suggested the feature to undo savestates and loadstates. After I successfully got merged my previous PR, I wanted to dig little deep into how the emulator works in general, so I made a rough version of feature.

I've added several functions to save_state_service.hpp to compatible with new ServiceLocator. types.hpp includes undoState and undoTimestamp to struct, and save_state_service.cpp got new slot-based undo methods for future expansion.
Other than that, it's almost exact same as old PR.
I've also modified actions.hpp, settings.hpp and cpp, and hotkeys_settings_view.cpp to ensure the compatibility with Qt UI.

Let me know if there's some flaws I made, or some changes I need to apply!