### PR TITLE
Feat/sh2 debug expand

### DIFF
--- a/apps/ymir-sdl3/CMakeLists.txt
+++ b/apps/ymir-sdl3/CMakeLists.txt
@@ -127,6 +127,8 @@ add_executable(ymir-sdl3
     src/app/ui/views/debug/sh2_cache_register_view.hpp
     src/app/ui/views/debug/sh2_debug_toolbar_view.cpp
     src/app/ui/views/debug/sh2_debug_toolbar_view.hpp
+    src/app/ui/views/debug/sh2_disasm_dump_view.cpp
+    src/app/ui/views/debug/sh2_disasm_dump_view.hpp
     src/app/ui/views/debug/sh2_disassembly_view.cpp
     src/app/ui/views/debug/sh2_disassembly_view.hpp
     src/app/ui/views/debug/sh2_divu_registers_view.cpp

--- a/apps/ymir-sdl3/src/app/events/emu_debug_event_factory.cpp
+++ b/apps/ymir-sdl3/src/app/events/emu_debug_event_factory.cpp
@@ -6,10 +6,24 @@
 
 #include <ymir/hw/sh1/sh1.hpp>
 #include <ymir/hw/sh2/sh2.hpp>
+#include <ymir/hw/sh2/sh2_disasm.hpp>
 #include <ymir/hw/vdp/vdp.hpp>
 #include <ymir/sys/bus.hpp>
+#include <ymir/util/dev_log.hpp>
+
+#include <fmt/format.h>
+
+#include <algorithm>
 
 namespace app::events::emu::debug {
+
+namespace grp {
+    struct base {
+        static constexpr bool enabled = true;
+        static constexpr devlog::Level level = devlog::level::debug;
+        static constexpr std::string_view name = "Emulator";
+    };
+} // namespace grp
 
 EmuEvent ExecuteSH2Division(bool master, bool div64) {
     if (div64) {
@@ -59,6 +73,228 @@ EmuEvent WriteSH2Memory(uint32 address, uint8 value, bool enableSideEffects, boo
             sh2.GetProbe().MemPokeByte(address, value, bypassCache);
         });
     }
+}
+
+// event to output specified disasm view into a formatted output
+EmuEvent DumpDisasmView(uint32 start, uint32 end, bool master) {
+    return RunFunction([=](SharedContext &ctx) {
+        // adress space ranges
+        constexpr uint32 kAddrMin = 0x00000000u;
+        constexpr uint32 kAddrMax = 0x07FFFFFEu;
+
+        // align addresses
+        uint32 rangeStart = start & ~1u;
+        uint32 rangeEnd = end & ~1u;
+        // ensure range order
+        if (rangeEnd < rangeStart) {
+            std::swap(rangeStart, rangeEnd);
+        }
+        // clamp bounds
+        rangeStart = std::clamp(rangeStart, kAddrMin, kAddrMax);
+        rangeEnd = std::clamp(rangeEnd, kAddrMin, kAddrMax);
+        if (rangeStart > rangeEnd) {
+            // should never happen, handle anyway
+            ctx.DisplayMessage("Invalid disassembly range");
+            return;
+        }
+
+        // fetch dump path, try creating dir
+        const auto dumpPath = ctx.profile.GetPath(ProfilePath::Dumps);
+        std::error_code ec{};
+        std::filesystem::create_directories(dumpPath, ec);
+        if (ec) {
+            devlog::warn<grp::base>("Could not create dump directory {}: {}", dumpPath, ec.message());
+            ctx.DisplayMessage("Failed to create dump directory");
+            return;
+        }
+
+        // add prefix for msh-2/ssh-2 
+        const char sh2Prefix = master ? 'm' : 's';
+        const auto outPath =
+            dumpPath / fmt::format("{}sh2-disasm_{:08X}_{:08X}.txt", sh2Prefix, rangeStart, rangeEnd);
+
+        // fetch output file stream to write to
+        std::ofstream out{outPath, std::ios::trunc};
+        if (!out) {
+            devlog::warn<grp::base>("Failed to open disassembly dump file {}", outPath);
+            ctx.DisplayMessage("Failed to open disassembly dump file");
+            return;
+        }
+
+        // switch mnemonic to string view
+        auto mnemonicToString = [](ymir::sh2::Mnemonic m) -> std::string_view {
+            using enum ymir::sh2::Mnemonic;
+            switch (m) {
+            case NOP: return "nop";
+            case SLEEP: return "sleep";
+            case MOV: return "mov";
+            case MOVA: return "mova";
+            case MOVT: return "movt";
+            case CLRT: return "clrt";
+            case SETT: return "sett";
+            case EXTU: return "extu";
+            case EXTS: return "exts";
+            case SWAP: return "swap";
+            case XTRCT: return "xtrct";
+            case LDC: return "ldc";
+            case LDS: return "lds";
+            case STC: return "stc";
+            case STS: return "sts";
+            case ADD: return "add";
+            case ADDC: return "addc";
+            case ADDV: return "addv";
+            case AND: return "and";
+            case NEG: return "neg";
+            case NEGC: return "negc";
+            case NOT: return "not";
+            case OR: return "or";
+            case ROTCL: return "rotcl";
+            case ROTCR: return "rotcr";
+            case ROTL: return "rotl";
+            case ROTR: return "rotr";
+            case SHAL: return "shal";
+            case SHAR: return "shar";
+            case SHLL: return "shll";
+            case SHLL2: return "shll2";
+            case SHLL8: return "shll8";
+            case SHLL16: return "shll16";
+            case SHLR: return "shlr";
+            case SHLR2: return "shlr2";
+            case SHLR8: return "shlr8";
+            case SHLR16: return "shlr16";
+            case SUB: return "sub";
+            case SUBC: return "subc";
+            case SUBV: return "subv";
+            case XOR: return "xor";
+            case DT: return "dt";
+            case CLRMAC: return "clrmac";
+            case MAC: return "mac";
+            case MUL: return "mul";
+            case MULS: return "muls";
+            case MULU: return "mulu";
+            case DMULS: return "dmuls";
+            case DMULU: return "dmulu";
+            case DIV0S: return "div0s";
+            case DIV0U: return "div0u";
+            case DIV1: return "div1";
+            case CMP_EQ: return "cmp/eq";
+            case CMP_GE: return "cmp/ge";
+            case CMP_GT: return "cmp/gt";
+            case CMP_HI: return "cmp/hi";
+            case CMP_HS: return "cmp/hs";
+            case CMP_PL: return "cmp/pl";
+            case CMP_PZ: return "cmp/pz";
+            case CMP_STR: return "cmp/str";
+            case TAS: return "tas";
+            case TST: return "tst";
+            case BF: return "bf";
+            case BFS: return "bfs";
+            case BT: return "bt";
+            case BTS: return "bts";
+            case BRA: return "bra";
+            case BRAF: return "braf";
+            case BSR: return "bsr";
+            case BSRF: return "bsrf";
+            case JMP: return "jmp";
+            case JSR: return "jsr";
+            case TRAPA: return "trapa";
+            case RTE: return "rte";
+            case RTS: return "rts";
+            case Illegal: return "(illegal)";
+            default: return "(?)";
+            }
+        };
+
+        // switch operand to string (more of the same)
+        auto opToString = [](uint32 address, const ymir::sh2::Operand &op) -> std::string {
+            using ymir::sh2::Operand;
+            using ymir::sh2::OperandSize;
+            switch (op.type) {
+            case Operand::Type::Imm: 
+                return fmt::format("#0x{:X}", static_cast<uint32>(op.immDisp));
+            case Operand::Type::Rn: 
+                return fmt::format("r{}", op.reg);
+            case Operand::Type::AtRn: 
+                return fmt::format("@r{}", op.reg);
+            case Operand::Type::AtRnPlus: 
+                return fmt::format("@r{}+", op.reg);
+            case Operand::Type::AtMinusRn: 
+                return fmt::format("@-r{}", op.reg);
+            case Operand::Type::AtDispRn: 
+                return fmt::format("@(0x{:X}, r{})", static_cast<uint32>(op.immDisp), op.reg);
+            case Operand::Type::AtR0Rn: 
+                return fmt::format("@(r0, r{})", op.reg);
+            case Operand::Type::AtDispGBR:
+                return fmt::format("@(0x{:X}, gbr)", static_cast<uint32>(op.immDisp));
+            case Operand::Type::AtR0GBR: 
+                return "@(r0, gbr)";
+            case Operand::Type::AtDispPC:
+                return fmt::format("@(0x{:X})", static_cast<uint32>(address + op.immDisp));
+            case Operand::Type::AtDispPCWordAlign:
+                return fmt::format("@(0x{:X})", static_cast<uint32>((address & ~3u) + op.immDisp));
+            case Operand::Type::AtRnPC: 
+                return fmt::format("@r{}+pc", op.reg);
+            case Operand::Type::DispPC: 
+                return fmt::format("0x{:X}", static_cast<uint32>(address + op.immDisp));
+            case Operand::Type::RnPC: 
+                return fmt::format("r{}+pc", op.reg);
+            case Operand::Type::SR: 
+                return "sr";
+            case Operand::Type::GBR: 
+                return "gbr";
+            case Operand::Type::VBR: 
+                return "vbr";
+            case Operand::Type::MACH: 
+                return "mach";
+            case Operand::Type::MACL: 
+                return "macl";
+            case Operand::Type::PR: 
+                return "pr";
+            default: return {};
+            }
+        };
+
+        // switch instruction to string (...more of the same)
+        auto instrToString = [&](uint32 address, uint16 opcode, const ymir::sh2::DisassembledInstruction &instr) {
+            std::string line = fmt::format("{:08X}: {:04X} {}", address, opcode, mnemonicToString(instr.mnemonic));
+            // operand size 
+            switch (instr.opSize) {
+            case ymir::sh2::OperandSize::Byte: line += ".b"; break;
+            case ymir::sh2::OperandSize::Word: line += ".w"; break;
+            case ymir::sh2::OperandSize::Long: line += ".l"; break;
+            default: break;
+            }
+            
+            // handle op1 and op2 -> string
+            std::string op1Str = opToString(address, instr.op1);
+            std::string op2Str = opToString(address, instr.op2);
+            if (!op1Str.empty()) {
+                line += " ";
+                line += op1Str;
+            }
+            if (!op2Str.empty()) {
+                line += op1Str.empty() ? " " : ", ";
+                line += op2Str;
+            }
+            return line;
+        };
+
+        // fetch saturn bus
+        auto &bus = ctx.saturn.GetMainBus();
+        // iterate over address range
+        for (uint32 addr = rangeStart;; addr += sizeof(uint16)) {
+            // fetch opcode from bus, then disasm
+            const uint16 opcode = bus.Peek<uint16>(addr);
+            const auto &disasm = ymir::sh2::Disassemble(opcode);
+            // write to output with newline
+            out << instrToString(addr, opcode, disasm) << "\n";
+            if (addr >= rangeEnd) {
+                break;
+            }
+        }
+
+        ctx.DisplayMessage(fmt::format("{}SH2 disassembly written to {}", (master ? "M" : "S"), outPath));
+    });
 }
 
 EmuEvent AddSH2Breakpoint(bool master, uint32 address) {

--- a/apps/ymir-sdl3/src/app/events/emu_debug_event_factory.cpp
+++ b/apps/ymir-sdl3/src/app/events/emu_debug_event_factory.cpp
@@ -87,7 +87,7 @@ EmuEvent DumpDisasmView(uint32 start, uint32 end, bool master, bool disasmDump, 
 
         // address space ranges
         constexpr uint32 kAddrMin = 0x00000000u;
-        constexpr uint32 kAddrMax = 0x07FFFFFEu;
+        constexpr uint32 kAddrMax = 0xFFFFFFFEu;
 
         // align addresses
         uint32 rangeStart = start & ~1u;

--- a/apps/ymir-sdl3/src/app/events/emu_debug_event_factory.hpp
+++ b/apps/ymir-sdl3/src/app/events/emu_debug_event_factory.hpp
@@ -16,7 +16,7 @@ EmuEvent WriteSH1Memory(uint32 address, uint8 value, bool enableSideEffects);
 EmuEvent WriteSH2Memory(uint32 address, uint8 value, bool enableSideEffects, bool master, bool bypassCache);
 
 // TODO: validate new EmuEvent in cpp implementation
-EmuEvent DumpDisasmView(uint32 start, uint32 end, bool master);
+EmuEvent DumpDisasmView(uint32 start, uint32 end, bool master, bool binaryDump);
 
 EmuEvent AddSH2Breakpoint(bool master, uint32 address);
 EmuEvent RemoveSH2Breakpoint(bool master, uint32 address);

--- a/apps/ymir-sdl3/src/app/events/emu_debug_event_factory.hpp
+++ b/apps/ymir-sdl3/src/app/events/emu_debug_event_factory.hpp
@@ -6,7 +6,6 @@
 
 #include "emu_event.hpp"
 
-#include <set>
 
 namespace app::events::emu::debug {
 
@@ -15,6 +14,9 @@ EmuEvent ExecuteSH2Division(bool master, bool div64);
 EmuEvent WriteMainMemory(uint32 address, uint8 value, bool enableSideEffects);
 EmuEvent WriteSH1Memory(uint32 address, uint8 value, bool enableSideEffects);
 EmuEvent WriteSH2Memory(uint32 address, uint8 value, bool enableSideEffects, bool master, bool bypassCache);
+
+// TODO: validate new EmuEvent in cpp implementation
+EmuEvent DumpDisasmView(uint32 start, uint32 end, bool master);
 
 EmuEvent AddSH2Breakpoint(bool master, uint32 address);
 EmuEvent RemoveSH2Breakpoint(bool master, uint32 address);

--- a/apps/ymir-sdl3/src/app/events/emu_debug_event_factory.hpp
+++ b/apps/ymir-sdl3/src/app/events/emu_debug_event_factory.hpp
@@ -16,7 +16,7 @@ EmuEvent WriteSH1Memory(uint32 address, uint8 value, bool enableSideEffects);
 EmuEvent WriteSH2Memory(uint32 address, uint8 value, bool enableSideEffects, bool master, bool bypassCache);
 
 // TODO: validate new EmuEvent in cpp implementation
-EmuEvent DumpDisasmView(uint32 start, uint32 end, bool master, bool binaryDump);
+EmuEvent DumpDisasmView(uint32 start, uint32 end, bool master, bool disasmDump, bool binaryDump);
 
 EmuEvent AddSH2Breakpoint(bool master, uint32 address);
 EmuEvent RemoveSH2Breakpoint(bool master, uint32 address);

--- a/apps/ymir-sdl3/src/app/events/emu_debug_event_factory.hpp
+++ b/apps/ymir-sdl3/src/app/events/emu_debug_event_factory.hpp
@@ -6,7 +6,6 @@
 
 #include "emu_event.hpp"
 
-
 namespace app::events::emu::debug {
 
 EmuEvent ExecuteSH2Division(bool master, bool div64);
@@ -15,7 +14,6 @@ EmuEvent WriteMainMemory(uint32 address, uint8 value, bool enableSideEffects);
 EmuEvent WriteSH1Memory(uint32 address, uint8 value, bool enableSideEffects);
 EmuEvent WriteSH2Memory(uint32 address, uint8 value, bool enableSideEffects, bool master, bool bypassCache);
 
-// TODO: validate new EmuEvent in cpp implementation
 EmuEvent DumpDisasmView(uint32 start, uint32 end, bool master, bool disasmDump, bool binaryDump);
 
 EmuEvent AddSH2Breakpoint(bool master, uint32 address);

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debug_toolbar_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debug_toolbar_view.cpp
@@ -17,7 +17,8 @@ namespace app::ui {
 
 SH2DebugToolbarView::SH2DebugToolbarView(SharedContext &context, sh2::SH2 &sh2)
     : m_context(context)
-    , m_sh2(sh2) {}
+    , m_sh2(sh2)
+    , m_disasmDumpView(context, sh2) {}
 
 void SH2DebugToolbarView::Display() {
     ImGui::BeginGroup();
@@ -115,20 +116,15 @@ void SH2DebugToolbarView::Display() {
         ImGui::EndTooltip();
     }
 
-    // TODO: add "dump disasm range" icon button
-    // - toggling opens imgui window
-    // - input for start:end range in hex
-    // - dump button enqueues EmuEvent to dump to text in dumpPath
-    // ImGui::SameLine -> if (Button){} toggle window -> ExplanationTooltip
-    // ImGui::SameLine();
-
-    //if (ImGui::Button()) {
-        // TODO: enqueue disasm dump event here once that is implemented
-    //}
-    //if (ImGui::BeginItemTooltip()) {
-    //    ImGui::TextUnformatted("Dump Disasm Range");
-    //    ImGui::EndTooltip();
-    //}
+    ImGui::SameLine();
+    if (ImGui::Button(ICON_MS_FILE_DOWNLOAD "##dump_disasm_range")) {
+        m_disasmDumpView.OpenPopup();
+    }
+    if (ImGui::BeginItemTooltip()) {
+        ImGui::TextUnformatted("Dump Disasm Range");
+        ImGui::EndTooltip();
+    }
+    m_disasmDumpView.Display();
 
     ImGui::SameLine();
     if (!m_context.saturn.IsDebugTracingEnabled()) {

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debug_toolbar_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debug_toolbar_view.cpp
@@ -106,6 +106,29 @@ void SH2DebugToolbarView::Display() {
             m_context.saturn.SetSlaveSH2Enabled(slaveSH2Enabled);
         }
     }
+    ImGui::SameLine();
+    if (ImGui::Button(ICON_MS_CENTER_FOCUS_WEAK "##follow_pc_toggle")) {
+        // TODO: enqueue follow PC toggle once implemented
+    }
+    if (ImGui::BeginItemTooltip()) {
+        ImGui::TextUnformatted("Follow PC");
+        ImGui::EndTooltip();
+    }
+
+    // TODO: add "dump disasm range" icon button
+    // - toggling opens imgui window
+    // - input for start:end range in hex
+    // - dump button enqueues EmuEvent to dump to text in dumpPath
+    // ImGui::SameLine -> if (Button){} toggle window -> ExplanationTooltip
+    // ImGui::SameLine();
+
+    //if (ImGui::Button()) {
+        // TODO: enqueue disasm dump event here once that is implemented
+    //}
+    //if (ImGui::BeginItemTooltip()) {
+    //    ImGui::TextUnformatted("Dump Disasm Range");
+    //    ImGui::EndTooltip();
+    //}
 
     ImGui::SameLine();
     if (!m_context.saturn.IsDebugTracingEnabled()) {

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debug_toolbar_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debug_toolbar_view.cpp
@@ -13,6 +13,8 @@
 
 #include <imgui.h>
 
+#include <cstdint>
+
 using namespace ymir;
 
 namespace app::ui {
@@ -148,6 +150,23 @@ void SH2DebugToolbarView::Display() {
     }
     widgets::ExplanationTooltip("Whether the CPU is in standby or sleep mode due to executing the SLEEP instruction.",
                                 m_context.displayScale);
+
+    // Input field to jump to address
+    static uint32_t jumpAddress = 0;
+    ImGui::SetNextItemWidth(100.0f * m_context.displayScale); // Width for 8 hex digits
+    ImGui::InputScalar("##jump_address", ImGuiDataType_U32, &jumpAddress, nullptr, nullptr, "%08X",
+                       ImGuiInputTextFlags_CharsHexadecimal);
+    ImGui::SameLine();
+    if (ImGui::Button("Jump")) {
+        constexpr uint32_t kSH2AddrMin = 0x00000000u;
+        constexpr uint32_t kSH2AddrMax = 0xFFFFFFFEu;
+        // ensure to clamp to valid SH2 address range (even addresses)
+        jumpAddress = (std::clamp<uint32_t>(jumpAddress, kSH2AddrMin, kSH2AddrMax) & ~1u);
+        m_model.jumpAddress = jumpAddress;
+        m_model.jumpRequested = true;
+        m_model.recenterWindow = true; // One-shot: request window recenter
+        m_model.followPC = false;
+    }
 
     ImGui::EndGroup();
 }

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debug_toolbar_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debug_toolbar_view.cpp
@@ -1,5 +1,7 @@
 #include "sh2_debug_toolbar_view.hpp"
 
+#include "sh2_disassembly_view.hpp"
+
 #include <ymir/hw/sh2/sh2.hpp>
 
 #include <app/events/emu_event_factory.hpp>
@@ -15,9 +17,10 @@ using namespace ymir;
 
 namespace app::ui {
 
-SH2DebugToolbarView::SH2DebugToolbarView(SharedContext &context, sh2::SH2 &sh2)
+SH2DebugToolbarView::SH2DebugToolbarView(SharedContext &context, sh2::SH2 &sh2, SH2DisassemblyView &disasmView)
     : m_context(context)
     , m_sh2(sh2)
+    , m_disasmView(disasmView)
     , m_disasmDumpView(context, sh2) {}
 
 void SH2DebugToolbarView::Display() {
@@ -109,7 +112,7 @@ void SH2DebugToolbarView::Display() {
     }
     ImGui::SameLine();
     if (ImGui::Button(ICON_MS_CENTER_FOCUS_WEAK "##follow_pc_toggle")) {
-        // TODO: enqueue follow PC toggle once implemented
+        m_disasmView.SetFollowPCEnabled(!m_disasmView.IsFollowPCEnabled());
     }
     if (ImGui::BeginItemTooltip()) {
         ImGui::TextUnformatted("Follow PC");

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debug_toolbar_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debug_toolbar_view.cpp
@@ -1,6 +1,6 @@
 #include "sh2_debug_toolbar_view.hpp"
 
-#include "sh2_disassembly_view.hpp"
+#include "sh2_debugger_model.hpp"
 
 #include <ymir/hw/sh2/sh2.hpp>
 
@@ -17,10 +17,10 @@ using namespace ymir;
 
 namespace app::ui {
 
-SH2DebugToolbarView::SH2DebugToolbarView(SharedContext &context, sh2::SH2 &sh2, SH2DisassemblyView &disasmView)
+SH2DebugToolbarView::SH2DebugToolbarView(SharedContext &context, sh2::SH2 &sh2, SH2DebuggerModel &model)
     : m_context(context)
     , m_sh2(sh2)
-    , m_disasmView(disasmView)
+    , m_model(model)
     , m_disasmDumpView(context, sh2) {}
 
 void SH2DebugToolbarView::Display() {
@@ -112,7 +112,7 @@ void SH2DebugToolbarView::Display() {
     }
     ImGui::SameLine();
     if (ImGui::Button(ICON_MS_CENTER_FOCUS_WEAK "##follow_pc_toggle")) {
-        m_disasmView.SetFollowPCEnabled(!m_disasmView.IsFollowPCEnabled());
+        m_model.followPC = !m_model.followPC;
     }
     if (ImGui::BeginItemTooltip()) {
         ImGui::TextUnformatted("Follow PC");

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debug_toolbar_view.hpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debug_toolbar_view.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <app/shared_context.hpp>
+#include <app/ui/views/debug/sh2_disasm_dump_view.hpp>
 
 namespace app::ui {
 
@@ -13,6 +14,7 @@ public:
 private:
     SharedContext &m_context;
     ymir::sh2::SH2 &m_sh2;
+    SH2DisasmDumpView m_disasmDumpView;
 };
 
 } // namespace app::ui

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debug_toolbar_view.hpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debug_toolbar_view.hpp
@@ -1,22 +1,21 @@
 #pragma once
 
 #include <app/shared_context.hpp>
+#include <app/ui/views/debug/sh2_debugger_model.hpp>
 #include <app/ui/views/debug/sh2_disasm_dump_view.hpp>
 
 namespace app::ui {
 
-class SH2DisassemblyView;
-
 class SH2DebugToolbarView {
 public:
-    SH2DebugToolbarView(SharedContext &context, ymir::sh2::SH2 &sh2, SH2DisassemblyView &disasmView);
+    SH2DebugToolbarView(SharedContext &context, ymir::sh2::SH2 &sh2, SH2DebuggerModel &model);
 
     void Display();
 
 private:
     SharedContext &m_context;
     ymir::sh2::SH2 &m_sh2;
-    SH2DisassemblyView &m_disasmView;
+    SH2DebuggerModel &m_model;
     SH2DisasmDumpView m_disasmDumpView;
 };
 

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debug_toolbar_view.hpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debug_toolbar_view.hpp
@@ -5,15 +5,18 @@
 
 namespace app::ui {
 
+class SH2DisassemblyView;
+
 class SH2DebugToolbarView {
 public:
-    SH2DebugToolbarView(SharedContext &context, ymir::sh2::SH2 &sh2);
+    SH2DebugToolbarView(SharedContext &context, ymir::sh2::SH2 &sh2, SH2DisassemblyView &disasmView);
 
     void Display();
 
 private:
     SharedContext &m_context;
     ymir::sh2::SH2 &m_sh2;
+    SH2DisassemblyView &m_disasmView;
     SH2DisasmDumpView m_disasmDumpView;
 };
 

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debugger_model.hpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debugger_model.hpp
@@ -6,9 +6,10 @@ namespace app::ui {
 
 /// Model/shared state for SH-2 debugger UI components (model-view pattern)
 struct SH2DebuggerModel {
-    bool followPC = true;       // Auto-follow PC in disassembly view
-    uint32 jumpAddress = 0;     // Pending jump target
-    bool jumpRequested = false; // Jump request flag
+    bool followPC = true;        // Auto-follow PC in disassembly view
+    uint32 jumpAddress = 0;      // Pending jump target
+    bool jumpRequested = false;  // Scroll animation request
+    bool recenterWindow = false; // One-shot: recenter view window on jump target
 };
 
 } // namespace app::ui

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debugger_model.hpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_debugger_model.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <ymir/core/types.hpp>
+
+namespace app::ui {
+
+/// Model/shared state for SH-2 debugger UI components (model-view pattern)
+struct SH2DebuggerModel {
+    bool followPC = true;       // Auto-follow PC in disassembly view
+    uint32 jumpAddress = 0;     // Pending jump target
+    bool jumpRequested = false; // Jump request flag
+};
+
+} // namespace app::ui

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disasm_dump_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disasm_dump_view.cpp
@@ -52,6 +52,7 @@ void SH2DisasmDumpView::Display() {
 
     ImGui::Checkbox("Keep open", &m_keepOpen);
     ImGui::Checkbox("Binary dump", &m_binDump);
+    ImGui::Checkbox("Disasm dump", &m_disasmDump);
 
     if (!m_errorMessage.empty()) {
         ImGui::TextColored(m_context.colors.warn, "%s", m_errorMessage.c_str());
@@ -66,7 +67,7 @@ void SH2DisasmDumpView::Display() {
             m_startAddress = start;
             m_endAddress = end;
             m_errorMessage.clear();
-            m_context.EnqueueEvent(events::emu::debug::DumpDisasmView(start, end, m_sh2.IsMaster(), m_binDump));
+            m_context.EnqueueEvent(events::emu::debug::DumpDisasmView(start, end, m_sh2.IsMaster(), m_disasmDump, m_binDump));
             if (!m_keepOpen) {
                 ImGui::CloseCurrentPopup();
             }

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disasm_dump_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disasm_dump_view.cpp
@@ -1,0 +1,92 @@
+#include "sh2_disasm_dump_view.hpp"
+
+#include <ymir/hw/sh2/sh2.hpp>
+
+#include <app/events/emu_debug_event_factory.hpp>
+
+#include <imgui.h>
+
+using namespace ymir;
+
+namespace app::ui {
+
+SH2DisasmDumpView::SH2DisasmDumpView(SharedContext &context, sh2::SH2 &sh2)
+    : m_context(context)
+    , m_sh2(sh2) {
+    ResetRangeFromPC();
+}
+
+void SH2DisasmDumpView::OpenPopup() {
+    ResetRangeFromPC();
+    m_errorMessage.clear();
+    ImGui::OpenPopup(kPopupName);
+}
+
+void SH2DisasmDumpView::Display() {
+    // enable auto resize
+    constexpr ImGuiWindowFlags flags = ImGuiWindowFlags_AlwaysAutoResize;
+
+    // try popup window
+    if (!ImGui::BeginPopupModal(kPopupName, nullptr, flags)) {
+        return;
+    }
+
+    // font, padding, width
+    const float fontSize = m_context.fontSizes.medium;
+    ImGui::PushFont(m_context.fonts.monospace.regular, fontSize);
+    const float hexCharWidth = ImGui::CalcTextSize("F").x;
+    ImGui::PopFont();
+    const float framePadding = ImGui::GetStyle().FramePadding.x;
+    const float fieldWidth = framePadding * 2 + hexCharWidth * 8;
+
+    ImGui::TextUnformatted("Address range (hex)");
+
+    ImGui::PushFont(m_context.fonts.monospace.regular, fontSize);
+    ImGui::SetNextItemWidth(fieldWidth);
+    ImGui::InputScalar("Start", ImGuiDataType_U32, &m_startAddress, nullptr, nullptr, "%08X",
+                       ImGuiInputTextFlags_CharsHexadecimal);
+    ImGui::SetNextItemWidth(fieldWidth);
+    ImGui::InputScalar("End", ImGuiDataType_U32, &m_endAddress, nullptr, nullptr, "%08X",
+                       ImGuiInputTextFlags_CharsHexadecimal);
+    ImGui::PopFont();
+
+    ImGui::Checkbox("Keep open", &m_keepOpen);
+    ImGui::Checkbox("Binary dump", &m_binDump);
+
+    if (!m_errorMessage.empty()) {
+        ImGui::TextColored(m_context.colors.warn, "%s", m_errorMessage.c_str());
+    }
+
+    if (ImGui::Button("Dump")) {
+        uint32 start = m_startAddress & ~1u;
+        uint32 end = m_endAddress & ~1u;
+        if (end < start) {
+            m_errorMessage = "Start address must be <= End address.";
+        } else {
+            m_startAddress = start;
+            m_endAddress = end;
+            m_errorMessage.clear();
+            m_context.EnqueueEvent(events::emu::debug::DumpDisasmView(start, end, m_sh2.IsMaster(), m_binDump));
+            if (!m_keepOpen) {
+                ImGui::CloseCurrentPopup();
+            }
+        }
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Close")) {
+        ImGui::CloseCurrentPopup();
+    }
+
+    ImGui::EndPopup();
+}
+
+void SH2DisasmDumpView::ResetRangeFromPC() {
+    const uint32 pc = m_sh2.GetProbe().PC() & ~1u;
+    constexpr uint32 window = 0x20;
+    const uint32 start = pc >= window ? pc - window : 0u;
+    const uint32 end = pc + window;
+    m_startAddress = start;
+    m_endAddress = end;
+}
+
+} // namespace app::ui

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disasm_dump_view.hpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disasm_dump_view.hpp
@@ -23,6 +23,7 @@ private:
     uint32 m_endAddress = 0;
     bool m_keepOpen = false;
     bool m_binDump = false;
+    bool m_disasmDump = true;
     std::string m_errorMessage;
 
     void ResetRangeFromPC();

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disasm_dump_view.hpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disasm_dump_view.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <app/shared_context.hpp>
+
+#include <string>
+
+namespace app::ui {
+
+class SH2DisasmDumpView {
+public:
+    SH2DisasmDumpView(SharedContext &context, ymir::sh2::SH2 &sh2);
+
+    void OpenPopup();
+    void Display();
+
+private:
+    static constexpr const char *kPopupName = "SH2 Disasm Dump";
+
+    SharedContext &m_context;
+    ymir::sh2::SH2 &m_sh2;
+
+    uint32 m_startAddress = 0;
+    uint32 m_endAddress = 0;
+    bool m_keepOpen = false;
+    bool m_binDump = false;
+    std::string m_errorMessage;
+
+    void ResetRangeFromPC();
+};
+
+} // namespace app::ui

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.cpp
@@ -57,7 +57,7 @@ void SH2DisassemblyView::Display() {
             ImGui::MenuItem("Colorize mnemonics by type", nullptr, &m_settings.colorizeMnemonicsByType);
 
             ImGui::Separator();
-            
+
             // new toggle to follow pc
             ImGui::MenuItem("Follow PC", nullptr, &m_state.followPC);
 
@@ -72,8 +72,9 @@ void SH2DisassemblyView::Display() {
     const float itemSpacing = ImGui::GetStyle().ItemSpacing.y;
     ImGui::PopFont();
 
+    // Compute line advance dynamically from font size (cached for use in scrolling)
+    m_lineAdvance = std::round(lineHeight + itemSpacing);
     auto availArea = ImGui::GetContentRegionAvail();
-    const float lineAdvance = std::round(lineHeight + itemSpacing);     // TODO: make this dynamic?
 
     if (ImGui::BeginChild("##disasm", availArea, ImGuiChildFlags_None, ImGuiWindowFlags_HorizontalScrollbar)) {
         // get draw list pointer and viewport height
@@ -88,82 +89,26 @@ void SH2DisassemblyView::Display() {
         const uint32 pc = probe.PC() & ~1u;
         const uint32 pr = probe.PR() & ~1u;
 
-        // bool to see if user moved window scroll
-        const bool scrolledByUser = ImGui::IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem) &&
-                                    (ImGui::GetIO().MouseWheel != 0.0f ||
-                                     ImGui::IsMouseDragging(ImGuiMouseButton_Left));
-        // if user scrolled, don't follow pc
-        if (scrolledByUser) {
+        // Detect user scroll to disable auto-follow
+        const float scrollDelta = ImGui::GetIO().MouseWheel;
+        if (ImGui::IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem) && std::abs(scrollDelta) > 0.1f) {
             m_state.followPC = false;
         }
-        const auto scrollToAddress = [&](uint32 targetAddress, bool continuousFollow) {
-            const uint32 clampedAddress = std::clamp(targetAddress, m_state.minAddress, m_state.maxAddress);
-            const uint32 lineIndex = (clampedAddress - m_state.minAddress) / sizeof(uint16);
-            const float lineTop = lineAdvance * static_cast<float>(lineIndex);
-            const float currentScroll = ImGui::GetScrollY();
 
-            // Smoothly scroll toward centering the target line.
-            const float lineCenter = lineTop + lineAdvance * 0.5f;
-            const float targetY = lineCenter - viewHeight * 0.5f;
-            const float clampedY = std::clamp(targetY, 0.0f, ImGui::GetScrollMaxY());
-            const float delta = clampedY - currentScroll;
-            const float absDelta = std::abs(delta);
-            if (continuousFollow) {
-                // Continuous follow: instant jump if far away; otherwise keep the line within
-                // a small margin and ease toward it with a capped per-frame step
-                const float currentCenter = currentScroll + viewHeight * 0.5f;
-                const float lineDelta = (lineCenter - currentCenter) / lineAdvance;
-                const float absLineDelta = std::abs(lineDelta);
-                const float viewTop = currentScroll;
-                const float viewBottom = currentScroll + viewHeight;
-                const bool lineOutOfView = lineTop < viewTop || (lineTop + lineAdvance) > viewBottom;
-                constexpr float kFollowMarginLines = 3.0f;
-                constexpr float kInstantJumpLines = 64.0f;
-
-                if (absLineDelta >= kInstantJumpLines) {
-                    ImGui::SetScrollY(clampedY);
-                    m_state.jumpRequested = false;
-                    return;
-                }
-
-                const float marginLines = lineOutOfView ? 0.0f : kFollowMarginLines;
-                if (absLineDelta <= marginLines) {
-                    m_state.jumpRequested = false;
-                    return;
-                }
-
-                const float desiredDeltaLines = absLineDelta - marginLines;
-                const float desiredDelta = std::copysign(desiredDeltaLines * lineAdvance, lineDelta);
-                const float desiredScroll = std::clamp(currentScroll + desiredDelta, 0.0f, ImGui::GetScrollMaxY());
-                const float adjustedDelta = desiredScroll - currentScroll;
-                const float maxStepLines = std::clamp(absLineDelta * 0.6f, 6.0f, 24.0f);
-                const float maxStep = lineAdvance * maxStepLines;
-                const float step = std::clamp(adjustedDelta, -maxStep, maxStep);
-                ImGui::SetScrollY(currentScroll + step);
-                m_state.jumpRequested = false;
-            } else {
-                const float stepFactor = absDelta > viewHeight ? 0.35f : 0.25f;
-                const float step = absDelta <= 1.0f ? delta : delta * stepFactor;
-                ImGui::SetScrollY(currentScroll + step);
-                m_state.jumpRequested = absDelta > 1.0f;
-            }
-        };
-
-        // jump to pc if we follow
+        // Handle scrolling to PC or jump address
         if (m_state.followPC) {
-            scrollToAddress(pc, true);
+            ScrollToAddress(pc, viewHeight, true);
         } else if (m_state.jumpRequested) {
-            scrollToAddress(m_state.jumpAddress, false);
+            ScrollToAddress(m_state.jumpAddress, viewHeight, false);
         }
 
-        // get total line count
         const int totalLines =
             static_cast<int>((m_state.maxAddress - m_state.minAddress) / sizeof(uint16)) + 1; // inclusive
 
         // ...sigh, we need to clip the list or else alternating line colors clip into toolbar on top
         // use a clipper so we only draw visible rows and keep background fills from bleeding outside the child area
         ImGuiListClipper clipper;
-        clipper.Begin(totalLines, lineAdvance);
+        clipper.Begin(totalLines, m_lineAdvance);
         while (clipper.Step()) {
             for (int lineIndex = clipper.DisplayStart; lineIndex < clipper.DisplayEnd; lineIndex++) {
                 const uint32 address = m_state.minAddress + static_cast<uint32>(lineIndex) * sizeof(uint16);
@@ -175,7 +120,7 @@ void SH2DisassemblyView::Display() {
 
                 const auto basePos = ImGui::GetCursorScreenPos();
                 // reserve vertical space for the line, then restore cursor to paint overlays/highlights at the top
-                ImGui::Dummy(ImVec2(ImGui::GetContentRegionAvail().x, lineAdvance));
+                ImGui::Dummy(ImVec2(ImGui::GetContentRegionAvail().x, m_lineAdvance));
                 const bool lineHovered = ImGui::IsItemHovered();
                 ImGui::SetCursorScreenPos(basePos);
 
@@ -184,653 +129,632 @@ void SH2DisassemblyView::Display() {
                     return m_sh2.IsBreakpointSet(address);
                 }();
 
-            auto toggleBreakpoint = [&] {
-                std::unique_lock lock{m_context.locks.breakpoints};
-                m_sh2.ToggleBreakpoint(address);
-                m_context.debuggers.MakeDirty();
-            };
-
-            auto memRead = [&](uint32 address) -> uint32 {
-                switch (disasm.opSize) {
-                case sh2::OperandSize::Byte: return probe.MemPeekByte(address, false);
-                case sh2::OperandSize::Word: return probe.MemPeekWord(address, false);
-                case sh2::OperandSize::Long: [[fallthrough]];
-                case sh2::OperandSize::LongImplicit: return probe.MemPeekLong(address, false);
-                default: return 0;
-                }
-            };
-
-            auto getOp = [&](const sh2::Operand &op) -> uint32 {
-                switch (op.type) {
-                case sh2::Operand::Type::Imm: return op.immDisp;
-                case sh2::Operand::Type::Rn: return probe.R(op.reg);
-                case sh2::Operand::Type::AtRn: return memRead(probe.R(op.reg));
-                case sh2::Operand::Type::AtRnPlus: return memRead(probe.R(op.reg));
-                case sh2::Operand::Type::AtMinusRn: return memRead(probe.R(op.reg));
-                case sh2::Operand::Type::AtDispRn: return memRead(probe.R(op.reg) + op.immDisp);
-                case sh2::Operand::Type::AtR0Rn: return memRead(probe.R(op.reg) + probe.R(0));
-                case sh2::Operand::Type::AtDispGBR: return memRead(probe.GBR() + op.immDisp);
-                case sh2::Operand::Type::AtR0GBR: return memRead(probe.GBR() + probe.R(0));
-                case sh2::Operand::Type::AtDispPC: return memRead(address + op.immDisp);
-                case sh2::Operand::Type::AtDispPCWordAlign: return memRead((address & ~3) + op.immDisp);
-                case sh2::Operand::Type::AtRnPC: return probe.R(op.reg);
-                case sh2::Operand::Type::DispPC: return memRead(address + op.immDisp);
-                case sh2::Operand::Type::RnPC: return probe.R(op.reg) + address;
-                case sh2::Operand::Type::SR: return probe.SR().u32;
-                case sh2::Operand::Type::GBR: return probe.GBR();
-                case sh2::Operand::Type::VBR: return probe.VBR();
-                case sh2::Operand::Type::MACH: return probe.MAC().H;
-                case sh2::Operand::Type::MACL: return probe.MAC().L;
-                case sh2::Operand::Type::PR: return probe.PR();
-                default: return 0;
-                }
-            };
-
-            auto getOp1 = [&] { return getOp(disasm.op1); };
-            auto getOp2 = [&] { return getOp(disasm.op2); };
-
-            auto filterAscii = [](char c) { return c < 0x20 ? '.' : c; };
-
-            auto drawHighlight = [&] {
-                ImVec4 color{};
-                bool filled = true;
-
-                /*if (address == m_cursor.address) {
-                    color = m_colors.disasm.cursorBgColor;
-                    if (!childWindowFocused) {
-                        filled = false;
-                    }
-                } else*/
-                if (address == pc) {
-                    color = m_colors.disasm.pcBgColor;
-                } else if (address == pr) {
-                    color = m_colors.disasm.prBgColor;
-                } else if (isBreakpointSet) {
-                    color = m_colors.disasm.bkptBgColor;
-                } else if (m_settings.altLineColors &&
-                           (m_settings.altLineAddresses ? (address & 2) : (lineIndex & 1))) {
-                    color = m_colors.disasm.altLineBgColor;
-                }
-                if (color.w == 0.0f) {
-                    return;
-                }
-                const ImVec2 size{ImGui::GetContentRegionAvail().x, lineHeight};
-                const ImVec2 rectPos{basePos.x, basePos.y};      // top-left corner of the current line
-                const ImVec2 rectEnd{basePos.x + size.x, basePos.y + size.y}; // bottom-right for highlight fill
-                if (filled) {
-                    drawList->AddRectFilled(rectPos, rectEnd, ImGui::ColorConvertFloat4ToU32(color));
-                } else {
-                    ImVec4 fillColor = color;
-                    fillColor.w *= 0.4f;
-                    auto borderPos = ImVec2(rectPos.x + 0.5f, rectPos.y + 0.5f);
-                    auto borderEnd = ImVec2(rectEnd.x - 0.5f, rectEnd.y - 0.5f);
-                    drawList->AddRectFilled(rectPos, rectEnd, ImGui::ColorConvertFloat4ToU32(fillColor));
-                    drawList->AddRect(borderPos, borderEnd, ImGui::ColorConvertFloat4ToU32(color), 0.0f,
-                                      ImDrawFlags_None, 2.0f);
-                }
-            };
-
-            auto drawIcons = [&] {
-                ImVec2 pos = basePos;
-                pos.x -= 1.5f;
-                pos.y -= 1.5f;
-                const ImVec2 baseCenter{pos.x + lineHeight * 0.5f, pos.y + lineHeight * 0.5f};
-
-                if (ImGui::InvisibleButton(fmt::format("toggle_bkpt_{}", address).c_str(),
-                                           ImVec2(lineHeight, lineHeight))) {
-                    toggleBreakpoint();
-                }
-                {
-                    const bool visible = isBreakpointSet;
-                    const bool hovered = ImGui::IsItemHovered();
-                    const bool active = ImGui::IsItemActive();
-
-                    if (visible || hovered || lineHovered) {
-                        const ImVec2 center = baseCenter;
-                        ImVec4 baseColor = active    ? m_colors.disasm.bkptActiveIconColor
-                                           : hovered ? m_colors.disasm.bkptHoveredIconColor
-                                                     : m_colors.disasm.bkptIconColor;
-                        if (!visible) {
-                            baseColor.w *= m_style.iconDisabledAlphaFactor;
-                        }
-                        const ImU32 color = ImGui::ColorConvertFloat4ToU32(baseColor);
-
-                        const float circleRadiusFactor = active ? 0.20f : hovered ? 0.30f : 0.25f;
-                        const float circleRadius = lineHeight * circleRadiusFactor;
-
-                        if (m_context.saturn.IsDebugTracingEnabled() && visible) {
-                            drawList->AddCircleFilled(center, circleRadius, color);
-                        } else {
-                            drawList->AddCircle(center, circleRadius, color, 0,
-                                                m_style.iconContourThickness * m_context.displayScale);
-                        }
-                    }
-                }
-                ImGui::SameLine(0.0f, 0.0f);
-
-                if (ImGui::InvisibleButton(fmt::format("set_pr_{}", address).c_str(), ImVec2(lineHeight, lineHeight))) {
-                    probe.PR() = address;
-                }
-                {
-                    const bool visible = address == pr;
-                    const bool hovered = ImGui::IsItemHovered();
-                    const bool active = ImGui::IsItemActive();
-
-                    if (visible || hovered || active) {
-                        ImVec4 baseColor = active    ? m_colors.disasm.prActiveIconColor
-                                           : hovered ? m_colors.disasm.prHoveredIconColor
-                                                     : m_colors.disasm.prIconColor;
-                        if (!visible) {
-                            baseColor.w *= m_style.iconDisabledAlphaFactor;
-                        }
-                        const ImU32 color = ImGui::ColorConvertFloat4ToU32(baseColor);
-
-                        const float sizeFactor = active ? 0.8f : hovered ? 1.2f : 1.0f;
-                        const ImVec2 center{baseCenter.x + lineHeight * 1.0f, baseCenter.y};
-                        const ImVec2 points[] = {
-                            {center.x - lineHeight * 0.25f * sizeFactor, center.y - lineHeight * 0.25f * sizeFactor},
-                            {center.x + lineHeight * 0.25f * sizeFactor, center.y},
-                            {center.x - lineHeight * 0.25f * sizeFactor, center.y + lineHeight * 0.25f * sizeFactor},
-                            {center.x - lineHeight * 0.15f * sizeFactor, center.y},
-                        };
-                        if (visible) {
-                            drawList->AddConcavePolyFilled(points, std::size(points), color);
-                        } else {
-                            drawList->AddPolyline(points, std::size(points), color, ImDrawFlags_Closed,
-                                                  m_style.iconContourThickness * m_context.displayScale);
-                        }
-                    }
-                }
-                ImGui::SameLine(0.0f, 0.0f);
-
-                if (ImGui::InvisibleButton(fmt::format("set_pc_{}", address).c_str(), ImVec2(lineHeight, lineHeight))) {
-                    probe.PC() = address;
-                }
-                {
-                    const bool visible = address == pc;
-                    const bool hovered = ImGui::IsItemHovered();
-                    const bool active = ImGui::IsItemActive();
-
-                    if (visible || hovered || active) {
-                        ImVec4 baseColor = active    ? m_colors.disasm.pcActiveIconColor
-                                           : hovered ? m_colors.disasm.pcHoveredIconColor
-                                                     : m_colors.disasm.pcIconColor;
-                        if (!visible) {
-                            baseColor.w *= m_style.iconDisabledAlphaFactor;
-                        }
-                        const ImU32 color = ImGui::ColorConvertFloat4ToU32(baseColor);
-
-                        const float sizeFactor = active ? 0.8f : hovered ? 1.2f : 1.0f;
-                        const ImVec2 center{baseCenter.x + lineHeight * 2.0f, baseCenter.y};
-                        const ImVec2 points[] = {
-                            {center.x - lineHeight * 0.25f * sizeFactor, center.y - lineHeight * 0.25f * sizeFactor},
-                            {center.x + lineHeight * 0.25f * sizeFactor, center.y},
-                            {center.x - lineHeight * 0.25f * sizeFactor, center.y + lineHeight * 0.25f * sizeFactor},
-                            {center.x - lineHeight * 0.15f * sizeFactor, center.y},
-                        };
-                        if (visible) {
-                            drawList->AddConcavePolyFilled(points, std::size(points), color);
-                        } else {
-                            drawList->AddPolyline(points, std::size(points), color, ImDrawFlags_Closed,
-                                                  m_style.iconContourThickness * m_context.displayScale);
-                        }
-                    }
-                }
-                ImGui::SameLine(0.0f, 0.0f);
-            };
-
-            auto drawAddress = [&] { ImGui::TextColored(m_colors.disasm.address, "%08X", address); };
-
-            auto drawOpcodeBytes = [&](bool display) {
-                if (display) {
-                    ImGui::TextColored(m_colors.disasm.bytes, "%04X", opcode);
-                }
-            };
-            auto drawOpcodeAscii = [&](bool display) {
-                if (display) {
-                    char ascii[2] = {0};
-                    ascii[0] = filterAscii((opcode >> 8) & 0xFF);
-                    ascii[1] = filterAscii((opcode >> 0) & 0xFF);
-                    ImGui::TextColored(m_colors.disasm.ascii, "%c%c", ascii[0], ascii[1]);
-                }
-            };
-
-            auto drawDelaySlotPrefix = [&] {
-                const float xofs = disasmCharSize.x * 2;
-                ImGui::SameLine(0, xofs);
-                ImVec2 startPos = ImGui::GetCursorScreenPos();
-                startPos.x -= xofs;
-
-                auto *drawList = ImGui::GetWindowDrawList();
-
-                const ImVec2 points[] = {
-                    ImVec2(startPos.x + disasmCharSize.x * 0.4f, startPos.y),
-                    ImVec2(startPos.x + disasmCharSize.x * 0.4f, startPos.y + disasmCharSize.y * 0.6f),
-                    ImVec2(startPos.x + disasmCharSize.x * 1.4f, startPos.y + disasmCharSize.y * 0.6f),
+                auto toggleBreakpoint = [&] {
+                    std::unique_lock lock{m_context.locks.breakpoints};
+                    m_sh2.ToggleBreakpoint(address);
+                    m_context.debuggers.MakeDirty();
                 };
-                drawList->AddPolyline(points, std::size(points),
-                                      ImGui::ColorConvertFloat4ToU32(m_colors.disasm.delaySlot), ImDrawFlags_None,
-                                      2.0f);
-                ImGui::Dummy(ImVec2(0, 0));
-            };
 
-            auto drawNopMnemonic = [&](std::string_view mnemonic) {
-                ImGui::SameLine(0, 0);
-                ImGui::TextColored(m_colors.disasm.nopMnemonic, "%s", mnemonic.data());
-            };
+                auto memRead = [&](uint32 address) -> uint32 {
+                    switch (disasm.opSize) {
+                    case sh2::OperandSize::Byte: return probe.MemPeekByte(address, false);
+                    case sh2::OperandSize::Word: return probe.MemPeekWord(address, false);
+                    case sh2::OperandSize::Long: [[fallthrough]];
+                    case sh2::OperandSize::LongImplicit: return probe.MemPeekLong(address, false);
+                    default: return 0;
+                    }
+                };
 
-            auto getMnemonicColor = [&](ImVec4 color) {
-                return m_settings.colorizeMnemonicsByType ? color : m_colors.disasm.mnemonic;
-            };
+                auto getOp = [&](const sh2::Operand &op) -> uint32 {
+                    switch (op.type) {
+                    case sh2::Operand::Type::Imm: return op.immDisp;
+                    case sh2::Operand::Type::Rn: return probe.R(op.reg);
+                    case sh2::Operand::Type::AtRn: return memRead(probe.R(op.reg));
+                    case sh2::Operand::Type::AtRnPlus: return memRead(probe.R(op.reg));
+                    case sh2::Operand::Type::AtMinusRn: return memRead(probe.R(op.reg));
+                    case sh2::Operand::Type::AtDispRn: return memRead(probe.R(op.reg) + op.immDisp);
+                    case sh2::Operand::Type::AtR0Rn: return memRead(probe.R(op.reg) + probe.R(0));
+                    case sh2::Operand::Type::AtDispGBR: return memRead(probe.GBR() + op.immDisp);
+                    case sh2::Operand::Type::AtR0GBR: return memRead(probe.GBR() + probe.R(0));
+                    case sh2::Operand::Type::AtDispPC: return memRead(address + op.immDisp);
+                    case sh2::Operand::Type::AtDispPCWordAlign: return memRead((address & ~3) + op.immDisp);
+                    case sh2::Operand::Type::AtRnPC: return probe.R(op.reg);
+                    case sh2::Operand::Type::DispPC: return memRead(address + op.immDisp);
+                    case sh2::Operand::Type::RnPC: return probe.R(op.reg) + address;
+                    case sh2::Operand::Type::SR: return probe.SR().u32;
+                    case sh2::Operand::Type::GBR: return probe.GBR();
+                    case sh2::Operand::Type::VBR: return probe.VBR();
+                    case sh2::Operand::Type::MACH: return probe.MAC().H;
+                    case sh2::Operand::Type::MACL: return probe.MAC().L;
+                    case sh2::Operand::Type::PR: return probe.PR();
+                    default: return 0;
+                    }
+                };
 
-            auto drawLoadStoreMnemonic = [&](std::string_view mnemonic) {
-                ImGui::SameLine(0, 0);
-                ImGui::TextColored(getMnemonicColor(m_colors.disasm.loadStoreMnemonic), "%s", mnemonic.data());
-            };
+                auto getOp1 = [&] { return getOp(disasm.op1); };
+                auto getOp2 = [&] { return getOp(disasm.op2); };
 
-            auto drawALUMnemonic = [&](std::string_view mnemonic) {
-                ImGui::SameLine(0, 0);
-                ImGui::TextColored(getMnemonicColor(m_colors.disasm.aluMnemonic), "%s", mnemonic.data());
-            };
+                auto filterAscii = [](char c) { return c < 0x20 ? '.' : c; };
 
-            auto drawBranchMnemonic = [&](std::string_view mnemonic) {
-                ImGui::SameLine(0, 0);
-                ImGui::TextColored(getMnemonicColor(m_colors.disasm.branchMnemonic), "%s", mnemonic.data());
-            };
+                auto drawHighlight = [&] {
+                    ImVec4 color{};
+                    bool filled = true;
 
-            auto drawControlMnemonic = [&](std::string_view mnemonic) {
-                ImGui::SameLine(0, 0);
-                ImGui::TextColored(getMnemonicColor(m_colors.disasm.controlMnemonic), "%s", mnemonic.data());
-            };
-
-            auto drawMiscMnemonic = [&](std::string_view mnemonic) {
-                ImGui::SameLine(0, 0);
-                ImGui::TextColored(getMnemonicColor(m_colors.disasm.miscMnemonic), "%s", mnemonic.data());
-            };
-
-            auto drawIllegalMnemonic = [&] {
-                ImGui::SameLine(0, 0);
-                ImGui::TextColored(m_colors.disasm.illegalMnemonic, "(illegal)");
-            };
-
-            auto drawUnknownMnemonic = [&] {
-                ImGui::SameLine(0, 0);
-                ImGui::TextColored(m_colors.disasm.illegalMnemonic, "(?)");
-            };
-
-            auto drawCond = [&](std::string_view cond, bool pass) {
-                ImGui::SameLine(0, 0);
-                const auto condColor = pass ? m_colors.disasm.condPass : m_colors.disasm.condFail;
-                ImGui::TextColored(condColor, "%s", cond.data());
-            };
-
-            auto drawSeparator = [&](std::string_view sep) {
-                ImGui::SameLine(0, 0);
-                ImGui::TextColored(m_colors.disasm.separator, "%s", sep.data());
-            };
-
-            auto drawSize = [&](std::string_view size) {
-                ImGui::SameLine(0, 0);
-                ImGui::TextColored(m_colors.disasm.separator, ".");
-                ImGui::SameLine(0, 0);
-                ImGui::TextColored(m_colors.disasm.sizeSuffix, "%s", size.data());
-            };
-
-            auto drawInstruction = [&] {
-                const float startX = ImGui::GetCursorPosX();
-                ImGui::Dummy(ImVec2(0, 0));
-
-                if (prevDisasm.hasDelaySlot) {
-                    if (!disasm.validInDelaySlot) {
-                        drawIllegalMnemonic();
+                    /*if (address == m_cursor.address) {
+                        color = m_colors.disasm.cursorBgColor;
+                        if (!childWindowFocused) {
+                            filled = false;
+                        }
+                    } else*/
+                    if (address == pc) {
+                        color = m_colors.disasm.pcBgColor;
+                    } else if (address == pr) {
+                        color = m_colors.disasm.prBgColor;
+                    } else if (isBreakpointSet) {
+                        color = m_colors.disasm.bkptBgColor;
+                    } else if (m_settings.altLineColors &&
+                               (m_settings.altLineAddresses ? (address & 2) : (lineIndex & 1))) {
+                        color = m_colors.disasm.altLineBgColor;
+                    }
+                    if (color.w == 0.0f) {
                         return;
                     }
-                    drawDelaySlotPrefix();
-                }
-
-                switch (disasm.mnemonic) {
-                case sh2::Mnemonic::NOP: drawNopMnemonic("nop"); break;
-                case sh2::Mnemonic::SLEEP: drawMiscMnemonic("sleep"); break;
-                case sh2::Mnemonic::MOV: drawLoadStoreMnemonic("mov"); break;
-                case sh2::Mnemonic::MOVA: drawLoadStoreMnemonic("mova"); break;
-                case sh2::Mnemonic::MOVT: drawLoadStoreMnemonic("movt"); break;
-                case sh2::Mnemonic::CLRT: drawControlMnemonic("clrt"); break;
-                case sh2::Mnemonic::SETT: drawControlMnemonic("sett"); break;
-                case sh2::Mnemonic::EXTU: drawALUMnemonic("extu"); break;
-                case sh2::Mnemonic::EXTS: drawALUMnemonic("exts"); break;
-                case sh2::Mnemonic::SWAP: drawALUMnemonic("swap"); break;
-                case sh2::Mnemonic::XTRCT: drawALUMnemonic("xtrct"); break;
-                case sh2::Mnemonic::LDC: drawControlMnemonic("ldc"); break;
-                case sh2::Mnemonic::LDS: drawControlMnemonic("lds"); break;
-                case sh2::Mnemonic::STC: drawControlMnemonic("stc"); break;
-                case sh2::Mnemonic::STS: drawControlMnemonic("sts"); break;
-                case sh2::Mnemonic::ADD: drawALUMnemonic("add"); break;
-                case sh2::Mnemonic::ADDC: drawALUMnemonic("addc"); break;
-                case sh2::Mnemonic::ADDV: drawALUMnemonic("addv"); break;
-                case sh2::Mnemonic::AND: drawALUMnemonic("and"); break;
-                case sh2::Mnemonic::NEG: drawALUMnemonic("neg"); break;
-                case sh2::Mnemonic::NEGC: drawALUMnemonic("negc"); break;
-                case sh2::Mnemonic::NOT: drawALUMnemonic("not"); break;
-                case sh2::Mnemonic::OR: drawALUMnemonic("or"); break;
-                case sh2::Mnemonic::ROTCL: drawALUMnemonic("rotcl"); break;
-                case sh2::Mnemonic::ROTCR: drawALUMnemonic("rotcr"); break;
-                case sh2::Mnemonic::ROTL: drawALUMnemonic("rotl"); break;
-                case sh2::Mnemonic::ROTR: drawALUMnemonic("rotr"); break;
-                case sh2::Mnemonic::SHAL: drawALUMnemonic("shal"); break;
-                case sh2::Mnemonic::SHAR: drawALUMnemonic("shar"); break;
-                case sh2::Mnemonic::SHLL: drawALUMnemonic("shll"); break;
-                case sh2::Mnemonic::SHLL2: drawALUMnemonic("shll2"); break;
-                case sh2::Mnemonic::SHLL8: drawALUMnemonic("shll8"); break;
-                case sh2::Mnemonic::SHLL16: drawALUMnemonic("shll16"); break;
-                case sh2::Mnemonic::SHLR: drawALUMnemonic("shlr"); break;
-                case sh2::Mnemonic::SHLR2: drawALUMnemonic("shlr2"); break;
-                case sh2::Mnemonic::SHLR8: drawALUMnemonic("shlr8"); break;
-                case sh2::Mnemonic::SHLR16: drawALUMnemonic("shlr16"); break;
-                case sh2::Mnemonic::SUB: drawALUMnemonic("sub"); break;
-                case sh2::Mnemonic::SUBC: drawALUMnemonic("subc"); break;
-                case sh2::Mnemonic::SUBV: drawALUMnemonic("subv"); break;
-                case sh2::Mnemonic::XOR: drawALUMnemonic("xor"); break;
-                case sh2::Mnemonic::DT: drawALUMnemonic("dt"); break;
-                case sh2::Mnemonic::CLRMAC: drawALUMnemonic("clrmac"); break;
-                case sh2::Mnemonic::MAC: drawALUMnemonic("mac"); break;
-                case sh2::Mnemonic::MUL: drawALUMnemonic("mul"); break;
-                case sh2::Mnemonic::MULS: drawALUMnemonic("muls"); break;
-                case sh2::Mnemonic::MULU: drawALUMnemonic("mulu"); break;
-                case sh2::Mnemonic::DMULS: drawALUMnemonic("dmuls"); break;
-                case sh2::Mnemonic::DMULU: drawALUMnemonic("dmulu"); break;
-                case sh2::Mnemonic::DIV0S: drawALUMnemonic("div0s"); break;
-                case sh2::Mnemonic::DIV0U: drawALUMnemonic("div0u"); break;
-                case sh2::Mnemonic::DIV1: drawALUMnemonic("div1"); break;
-                case sh2::Mnemonic::CMP_EQ:
-                    drawALUMnemonic("cmp");
-                    drawSeparator("/");
-                    drawCond("eq", getOp1() == getOp2());
-                    break;
-                case sh2::Mnemonic::CMP_GE:
-                    drawALUMnemonic("cmp");
-                    drawSeparator("/");
-                    drawCond("ge", static_cast<sint32>(getOp1()) >= static_cast<sint32>(getOp2()));
-                    break;
-                case sh2::Mnemonic::CMP_GT:
-                    drawALUMnemonic("cmp");
-                    drawSeparator("/");
-                    drawCond("gt", static_cast<sint32>(getOp1()) > static_cast<sint32>(getOp2()));
-                    break;
-                case sh2::Mnemonic::CMP_HI:
-                    drawALUMnemonic("cmp");
-                    drawSeparator("/");
-                    drawCond("hi", getOp1() > getOp2());
-                    break;
-                case sh2::Mnemonic::CMP_HS:
-                    drawALUMnemonic("cmp");
-                    drawSeparator("/");
-                    drawCond("hs", getOp1() >= getOp2());
-                    break;
-                case sh2::Mnemonic::CMP_PL:
-                    drawALUMnemonic("cmp");
-                    drawSeparator("/");
-                    drawCond("pl", static_cast<sint32>(getOp1()) > 0);
-                    break;
-                case sh2::Mnemonic::CMP_PZ:
-                    drawALUMnemonic("cmp");
-                    drawSeparator("/");
-                    drawCond("pz", static_cast<sint32>(getOp1()) >= 0);
-                    break;
-                case sh2::Mnemonic::CMP_STR: //
-                {
-                    const uint32 tmp = getOp1() ^ getOp2();
-                    const uint8 hh = tmp >> 24u;
-                    const uint8 hl = tmp >> 16u;
-                    const uint8 lh = tmp >> 8u;
-                    const uint8 ll = tmp >> 0u;
-                    drawALUMnemonic("cmp");
-                    drawSeparator("/");
-                    drawCond("str", !(hh && hl && lh && ll));
-                    break;
-                }
-                case sh2::Mnemonic::TAS: drawLoadStoreMnemonic("tas"); break;
-                case sh2::Mnemonic::TST: drawALUMnemonic("tst"); break;
-                case sh2::Mnemonic::BF:
-                    drawBranchMnemonic("b");
-                    drawCond("f", !probe.SR().T);
-                    break;
-                case sh2::Mnemonic::BFS:
-                    drawBranchMnemonic("b");
-                    drawCond("f", !probe.SR().T);
-                    drawSeparator("/");
-                    drawBranchMnemonic("s");
-                    break;
-                case sh2::Mnemonic::BT:
-                    drawBranchMnemonic("b");
-                    drawCond("t", probe.SR().T);
-                    break;
-                case sh2::Mnemonic::BTS:
-                    drawBranchMnemonic("b");
-                    drawCond("t", probe.SR().T);
-                    drawSeparator("/");
-                    drawBranchMnemonic("s");
-                    break;
-                case sh2::Mnemonic::BRA: drawBranchMnemonic("bra"); break;
-                case sh2::Mnemonic::BRAF: drawBranchMnemonic("braf"); break;
-                case sh2::Mnemonic::BSR: drawBranchMnemonic("bsr"); break;
-                case sh2::Mnemonic::BSRF: drawBranchMnemonic("bsrf"); break;
-                case sh2::Mnemonic::JMP: drawBranchMnemonic("jmp"); break;
-                case sh2::Mnemonic::JSR: drawBranchMnemonic("jsr"); break;
-                case sh2::Mnemonic::TRAPA: drawBranchMnemonic("trapa"); break;
-                case sh2::Mnemonic::RTE: drawBranchMnemonic("rte"); break;
-                case sh2::Mnemonic::RTS: drawBranchMnemonic("rts"); break;
-                case sh2::Mnemonic::Illegal: drawIllegalMnemonic(); break;
-                default: drawUnknownMnemonic(); break;
-                }
-
-                switch (disasm.opSize) {
-                case sh2::OperandSize::Byte: drawSize("b"); break;
-                case sh2::OperandSize::Word: drawSize("w"); break;
-                case sh2::OperandSize::Long: drawSize("l"); break;
-                default: break;
-                }
-
-                ImGui::SameLine(0, 0);
-                const float endX = ImGui::GetCursorPosX();
-                ImGui::SameLine(0, disasmCharSize.x * 10 - endX + startX);
-                ImGui::Dummy(ImVec2(0, 0));
-            };
-
-            auto drawImm = [&](sint32 imm) {
-                ImGui::TextColored(m_colors.disasm.immediate, "#0x%X", static_cast<uint32>(imm));
-            };
-
-            auto drawRegRead = [&](std::string_view regName) {
-                ImGui::TextColored(m_colors.disasm.regRead, "%s", regName.data());
-            };
-
-            auto drawRegWrite = [&](std::string_view regName) {
-                ImGui::TextColored(m_colors.disasm.regWrite, "%s", regName.data());
-            };
-
-            auto drawRegReadWrite = [&](std::string_view regName) {
-                ImGui::TextColored(m_colors.disasm.regReadWrite, "%s", regName.data());
-            };
-
-            auto drawReg = [&](std::string_view regName, bool read, bool write) {
-                if (read && write) {
-                    drawRegReadWrite(regName);
-                } else if (write) {
-                    drawRegWrite(regName);
-                } else {
-                    drawRegRead(regName);
-                }
-            };
-
-            auto drawRnRead = [&](uint8 rn) { ImGui::TextColored(m_colors.disasm.regRead, "r%u", rn); };
-            auto drawRnWrite = [&](uint8 rn) { ImGui::TextColored(m_colors.disasm.regWrite, "r%u", rn); };
-            auto drawRnReadWrite = [&](uint8 rn) { ImGui::TextColored(m_colors.disasm.regReadWrite, "r%u", rn); };
-
-            auto drawRn = [&](uint8 rn, bool read, bool write) {
-                if (read && write) {
-                    drawRnReadWrite(rn);
-                } else if (write) {
-                    drawRnWrite(rn);
-                } else {
-                    drawRnRead(rn);
-                }
-            };
-
-            auto drawRWSymbol = [&](std::string_view symbol, bool write) {
-                const auto color = write ? m_colors.disasm.regWrite : m_colors.disasm.regRead;
-                ImGui::TextColored(color, "%s", symbol.data());
-            };
-
-            auto drawPlus = [&] { ImGui::TextColored(m_colors.disasm.addrInc, "+"); };
-            auto drawMinus = [&] { ImGui::TextColored(m_colors.disasm.addrDec, "-"); };
-            auto drawComma = [&] { ImGui::TextColored(m_colors.disasm.separator, ", "); };
-
-            auto drawOp = [&](const sh2::Operand &op) {
-                if (op.type == sh2::Operand::Type::None) {
-                    return false;
-                }
-
-                switch (op.type) {
-                case sh2::Operand::Type::Imm: drawImm(op.immDisp); break;
-                case sh2::Operand::Type::Rn: drawRn(op.reg, op.read, op.write); break;
-                case sh2::Operand::Type::AtRn:
-                    drawRWSymbol("@", op.write);
-                    ImGui::SameLine(0, 0);
-                    drawRnRead(op.reg);
-                    break;
-                case sh2::Operand::Type::AtRnPlus:
-                    drawRWSymbol("@", op.write);
-                    ImGui::SameLine(0, 0);
-                    drawRnReadWrite(op.reg);
-                    ImGui::SameLine(0, 0);
-                    drawPlus();
-                    break;
-                case sh2::Operand::Type::AtMinusRn:
-                    drawRWSymbol("@", op.write);
-                    ImGui::SameLine(0, 0);
-                    drawMinus();
-                    ImGui::SameLine(0, 0);
-                    drawRnReadWrite(op.reg);
-                    break;
-                case sh2::Operand::Type::AtDispRn:
-                    drawRWSymbol("@(", op.write);
-                    ImGui::SameLine(0, 0);
-                    drawImm(op.immDisp);
-                    ImGui::SameLine(0, 0);
-                    drawComma();
-                    ImGui::SameLine(0, 0);
-                    drawRnRead(op.reg);
-                    ImGui::SameLine(0, 0);
-                    drawRWSymbol(")", op.write);
-                    break;
-                case sh2::Operand::Type::AtR0Rn:
-                    drawRWSymbol("@(", op.write);
-                    ImGui::SameLine(0, 0);
-                    drawRnRead(0);
-                    ImGui::SameLine(0, 0);
-                    drawComma();
-                    ImGui::SameLine(0, 0);
-                    drawRnRead(op.reg);
-                    ImGui::SameLine(0, 0);
-                    drawRWSymbol(")", op.write);
-                    break;
-                case sh2::Operand::Type::AtDispGBR:
-                    drawRWSymbol("@(", op.write);
-                    ImGui::SameLine(0, 0);
-                    drawImm(op.immDisp);
-                    ImGui::SameLine(0, 0);
-                    drawComma();
-                    ImGui::SameLine(0, 0);
-                    drawRegRead("gbr");
-                    ImGui::SameLine(0, 0);
-                    drawRWSymbol(")", op.write);
-                    break;
-                case sh2::Operand::Type::AtR0GBR:
-                    drawRWSymbol("@(", op.write);
-                    ImGui::SameLine(0, 0);
-                    drawRnRead(0);
-                    ImGui::SameLine(0, 0);
-                    drawComma();
-                    ImGui::SameLine(0, 0);
-                    drawRegRead("gbr");
-                    ImGui::SameLine(0, 0);
-                    drawRWSymbol(")", op.write);
-                    break;
-                case sh2::Operand::Type::AtDispPC:
-                    drawRWSymbol("@(", false);
-                    ImGui::SameLine(0, 0);
-                    drawImm(address + op.immDisp);
-                    ImGui::SameLine(0, 0);
-                    drawRWSymbol(")", false);
-                    break;
-                case sh2::Operand::Type::AtDispPCWordAlign:
-                    drawRWSymbol("@(", false);
-                    ImGui::SameLine(0, 0);
-                    drawImm((address & ~3) + op.immDisp);
-                    ImGui::SameLine(0, 0);
-                    drawRWSymbol(")", false);
-                    break;
-                case sh2::Operand::Type::AtRnPC:
-                    drawRWSymbol("@", op.write);
-                    ImGui::SameLine(0, 0);
-                    drawRnRead(op.reg);
-                    break;
-                case sh2::Operand::Type::DispPC: drawImm(address + op.immDisp); break;
-                case sh2::Operand::Type::RnPC: drawRnRead(op.reg); break;
-                case sh2::Operand::Type::SR: drawReg("sr", op.read, op.write); break;
-                case sh2::Operand::Type::GBR: drawReg("gbr", op.read, op.write); break;
-                case sh2::Operand::Type::VBR: drawReg("vbr", op.read, op.write); break;
-                case sh2::Operand::Type::MACH: drawReg("mach", op.read, op.write); break;
-                case sh2::Operand::Type::MACL: drawReg("macl", op.read, op.write); break;
-                case sh2::Operand::Type::PR: drawReg("pr", op.read, op.write); break;
-                default: return false;
-                }
-
-                return true;
-            };
-
-            auto drawOp1 = [&] { return drawOp(disasm.op1); };
-            auto drawOp2 = [&] { return drawOp(disasm.op2); };
-
-            // -------------------------------------------------------------------------------------------------------------
-
-            ImGui::BeginGroup();
-            {
-                drawHighlight();
-                drawIcons();
-                drawAddress();
-                ImGui::SameLine(0.0f, m_style.disasmSpacing);
-                drawOpcodeBytes(m_settings.displayOpcodeBytes);
-                ImGui::SameLine(0.0f, m_style.disasmSpacing);
-                drawOpcodeAscii(m_settings.displayOpcodeAscii);
-                ImGui::SameLine(0.0f, m_style.disasmSpacing);
-                drawInstruction();
-                if (disasm.op1.type != sh2::Operand::Type::None) {
-                    ImGui::SameLine(0, 0);
-                    drawOp1();
-                }
-                if (disasm.op2.type != sh2::Operand::Type::None) {
-                    if (disasm.op1.type != sh2::Operand::Type::None) {
-                        ImGui::SameLine(0, 0);
-                        ImGui::TextColored(m_colors.disasm.separator, ", ");
+                    const ImVec2 size{ImGui::GetContentRegionAvail().x, lineHeight};
+                    const ImVec2 rectPos{basePos.x, basePos.y};                   // top-left corner of the current line
+                    const ImVec2 rectEnd{basePos.x + size.x, basePos.y + size.y}; // bottom-right for highlight fill
+                    if (filled) {
+                        drawList->AddRectFilled(rectPos, rectEnd, ImGui::ColorConvertFloat4ToU32(color));
+                    } else {
+                        ImVec4 fillColor = color;
+                        fillColor.w *= 0.4f;
+                        auto borderPos = ImVec2(rectPos.x + 0.5f, rectPos.y + 0.5f);
+                        auto borderEnd = ImVec2(rectEnd.x - 0.5f, rectEnd.y - 0.5f);
+                        drawList->AddRectFilled(rectPos, rectEnd, ImGui::ColorConvertFloat4ToU32(fillColor));
+                        drawList->AddRect(borderPos, borderEnd, ImGui::ColorConvertFloat4ToU32(color), 0.0f,
+                                          ImDrawFlags_None, 2.0f);
                     }
-                    ImGui::SameLine(0, 0);
-                    drawOp2();
-                }
-                // TODO: show short annotations
-                ImGui::SameLine(0, 0);
-                ImGui::Dummy(ImVec2(ImGui::GetContentRegionAvail().x, lineHeight));
-            }
-            ImGui::EndGroup();
+                };
 
-            if (lineHovered) {
-                if (ImGui::BeginTooltip()) {
+                auto drawIcons = [&] {
+                    ImVec2 pos = basePos;
+                    pos.x -= 1.5f;
+                    pos.y -= 1.5f;
+                    const ImVec2 baseCenter{pos.x + lineHeight * 0.5f, pos.y + lineHeight * 0.5f};
+
+                    if (ImGui::InvisibleButton(fmt::format("toggle_bkpt_{}", address).c_str(),
+                                               ImVec2(lineHeight, lineHeight))) {
+                        toggleBreakpoint();
+                    }
+                    {
+                        const bool visible = isBreakpointSet;
+                        const bool hovered = ImGui::IsItemHovered();
+                        const bool active = ImGui::IsItemActive();
+
+                        if (visible || hovered || lineHovered) {
+                            const ImVec2 center = baseCenter;
+                            ImVec4 baseColor = active    ? m_colors.disasm.bkptActiveIconColor
+                                               : hovered ? m_colors.disasm.bkptHoveredIconColor
+                                                         : m_colors.disasm.bkptIconColor;
+                            if (!visible) {
+                                baseColor.w *= m_style.iconDisabledAlphaFactor;
+                            }
+                            const ImU32 color = ImGui::ColorConvertFloat4ToU32(baseColor);
+
+                            const float circleRadiusFactor = active ? 0.20f : hovered ? 0.30f : 0.25f;
+                            const float circleRadius = lineHeight * circleRadiusFactor;
+
+                            if (m_context.saturn.IsDebugTracingEnabled() && visible) {
+                                drawList->AddCircleFilled(center, circleRadius, color);
+                            } else {
+                                drawList->AddCircle(center, circleRadius, color, 0,
+                                                    m_style.iconContourThickness * m_context.displayScale);
+                            }
+                        }
+                    }
+                    ImGui::SameLine(0.0f, 0.0f);
+
+                    if (ImGui::InvisibleButton(fmt::format("set_pr_{}", address).c_str(),
+                                               ImVec2(lineHeight, lineHeight))) {
+                        probe.PR() = address;
+                    }
+                    {
+                        const bool visible = address == pr;
+                        const bool hovered = ImGui::IsItemHovered();
+                        const bool active = ImGui::IsItemActive();
+
+                        if (visible || hovered || active) {
+                            ImVec4 baseColor = active    ? m_colors.disasm.prActiveIconColor
+                                               : hovered ? m_colors.disasm.prHoveredIconColor
+                                                         : m_colors.disasm.prIconColor;
+                            if (!visible) {
+                                baseColor.w *= m_style.iconDisabledAlphaFactor;
+                            }
+                            const ImU32 color = ImGui::ColorConvertFloat4ToU32(baseColor);
+
+                            const float sizeFactor = active ? 0.8f : hovered ? 1.2f : 1.0f;
+                            const ImVec2 center{baseCenter.x + lineHeight * 1.0f, baseCenter.y};
+                            const ImVec2 points[] = {
+                                {center.x - lineHeight * 0.25f * sizeFactor,
+                                 center.y - lineHeight * 0.25f * sizeFactor},
+                                {center.x + lineHeight * 0.25f * sizeFactor, center.y},
+                                {center.x - lineHeight * 0.25f * sizeFactor,
+                                 center.y + lineHeight * 0.25f * sizeFactor},
+                                {center.x - lineHeight * 0.15f * sizeFactor, center.y},
+                            };
+                            if (visible) {
+                                drawList->AddConcavePolyFilled(points, std::size(points), color);
+                            } else {
+                                drawList->AddPolyline(points, std::size(points), color, ImDrawFlags_Closed,
+                                                      m_style.iconContourThickness * m_context.displayScale);
+                            }
+                        }
+                    }
+                    ImGui::SameLine(0.0f, 0.0f);
+
+                    if (ImGui::InvisibleButton(fmt::format("set_pc_{}", address).c_str(),
+                                               ImVec2(lineHeight, lineHeight))) {
+                        probe.PC() = address;
+                    }
+                    {
+                        const bool visible = address == pc;
+                        const bool hovered = ImGui::IsItemHovered();
+                        const bool active = ImGui::IsItemActive();
+
+                        if (visible || hovered || active) {
+                            ImVec4 baseColor = active    ? m_colors.disasm.pcActiveIconColor
+                                               : hovered ? m_colors.disasm.pcHoveredIconColor
+                                                         : m_colors.disasm.pcIconColor;
+                            if (!visible) {
+                                baseColor.w *= m_style.iconDisabledAlphaFactor;
+                            }
+                            const ImU32 color = ImGui::ColorConvertFloat4ToU32(baseColor);
+
+                            const float sizeFactor = active ? 0.8f : hovered ? 1.2f : 1.0f;
+                            const ImVec2 center{baseCenter.x + lineHeight * 2.0f, baseCenter.y};
+                            const ImVec2 points[] = {
+                                {center.x - lineHeight * 0.25f * sizeFactor,
+                                 center.y - lineHeight * 0.25f * sizeFactor},
+                                {center.x + lineHeight * 0.25f * sizeFactor, center.y},
+                                {center.x - lineHeight * 0.25f * sizeFactor,
+                                 center.y + lineHeight * 0.25f * sizeFactor},
+                                {center.x - lineHeight * 0.15f * sizeFactor, center.y},
+                            };
+                            if (visible) {
+                                drawList->AddConcavePolyFilled(points, std::size(points), color);
+                            } else {
+                                drawList->AddPolyline(points, std::size(points), color, ImDrawFlags_Closed,
+                                                      m_style.iconContourThickness * m_context.displayScale);
+                            }
+                        }
+                    }
+                    ImGui::SameLine(0.0f, 0.0f);
+                };
+
+                auto drawAddress = [&] { ImGui::TextColored(m_colors.disasm.address, "%08X", address); };
+
+                auto drawOpcodeBytes = [&](bool display) {
+                    if (display) {
+                        ImGui::TextColored(m_colors.disasm.bytes, "%04X", opcode);
+                    }
+                };
+                auto drawOpcodeAscii = [&](bool display) {
+                    if (display) {
+                        char ascii[2] = {0};
+                        ascii[0] = filterAscii((opcode >> 8) & 0xFF);
+                        ascii[1] = filterAscii((opcode >> 0) & 0xFF);
+                        ImGui::TextColored(m_colors.disasm.ascii, "%c%c", ascii[0], ascii[1]);
+                    }
+                };
+
+                auto drawDelaySlotPrefix = [&] {
+                    const float xofs = disasmCharSize.x * 2;
+                    ImGui::SameLine(0, xofs);
+                    ImVec2 startPos = ImGui::GetCursorScreenPos();
+                    startPos.x -= xofs;
+
+                    auto *drawList = ImGui::GetWindowDrawList();
+
+                    const ImVec2 points[] = {
+                        ImVec2(startPos.x + disasmCharSize.x * 0.4f, startPos.y),
+                        ImVec2(startPos.x + disasmCharSize.x * 0.4f, startPos.y + disasmCharSize.y * 0.6f),
+                        ImVec2(startPos.x + disasmCharSize.x * 1.4f, startPos.y + disasmCharSize.y * 0.6f),
+                    };
+                    drawList->AddPolyline(points, std::size(points),
+                                          ImGui::ColorConvertFloat4ToU32(m_colors.disasm.delaySlot), ImDrawFlags_None,
+                                          2.0f);
+                    ImGui::Dummy(ImVec2(0, 0));
+                };
+
+                auto drawNopMnemonic = [&](std::string_view mnemonic) {
+                    ImGui::SameLine(0, 0);
+                    ImGui::TextColored(m_colors.disasm.nopMnemonic, "%s", mnemonic.data());
+                };
+
+                auto getMnemonicColor = [&](ImVec4 color) {
+                    return m_settings.colorizeMnemonicsByType ? color : m_colors.disasm.mnemonic;
+                };
+
+                auto drawLoadStoreMnemonic = [&](std::string_view mnemonic) {
+                    ImGui::SameLine(0, 0);
+                    ImGui::TextColored(getMnemonicColor(m_colors.disasm.loadStoreMnemonic), "%s", mnemonic.data());
+                };
+
+                auto drawALUMnemonic = [&](std::string_view mnemonic) {
+                    ImGui::SameLine(0, 0);
+                    ImGui::TextColored(getMnemonicColor(m_colors.disasm.aluMnemonic), "%s", mnemonic.data());
+                };
+
+                auto drawBranchMnemonic = [&](std::string_view mnemonic) {
+                    ImGui::SameLine(0, 0);
+                    ImGui::TextColored(getMnemonicColor(m_colors.disasm.branchMnemonic), "%s", mnemonic.data());
+                };
+
+                auto drawControlMnemonic = [&](std::string_view mnemonic) {
+                    ImGui::SameLine(0, 0);
+                    ImGui::TextColored(getMnemonicColor(m_colors.disasm.controlMnemonic), "%s", mnemonic.data());
+                };
+
+                auto drawMiscMnemonic = [&](std::string_view mnemonic) {
+                    ImGui::SameLine(0, 0);
+                    ImGui::TextColored(getMnemonicColor(m_colors.disasm.miscMnemonic), "%s", mnemonic.data());
+                };
+
+                auto drawIllegalMnemonic = [&] {
+                    ImGui::SameLine(0, 0);
+                    ImGui::TextColored(m_colors.disasm.illegalMnemonic, "(illegal)");
+                };
+
+                auto drawUnknownMnemonic = [&] {
+                    ImGui::SameLine(0, 0);
+                    ImGui::TextColored(m_colors.disasm.illegalMnemonic, "(?)");
+                };
+
+                auto drawCond = [&](std::string_view cond, bool pass) {
+                    ImGui::SameLine(0, 0);
+                    const auto condColor = pass ? m_colors.disasm.condPass : m_colors.disasm.condFail;
+                    ImGui::TextColored(condColor, "%s", cond.data());
+                };
+
+                auto drawSeparator = [&](std::string_view sep) {
+                    ImGui::SameLine(0, 0);
+                    ImGui::TextColored(m_colors.disasm.separator, "%s", sep.data());
+                };
+
+                auto drawSize = [&](std::string_view size) {
+                    ImGui::SameLine(0, 0);
+                    ImGui::TextColored(m_colors.disasm.separator, ".");
+                    ImGui::SameLine(0, 0);
+                    ImGui::TextColored(m_colors.disasm.sizeSuffix, "%s", size.data());
+                };
+
+                auto drawInstruction = [&] {
+                    const float startX = ImGui::GetCursorPosX();
+                    ImGui::Dummy(ImVec2(0, 0));
+
+                    if (prevDisasm.hasDelaySlot) {
+                        if (!disasm.validInDelaySlot) {
+                            drawIllegalMnemonic();
+                            return;
+                        }
+                        drawDelaySlotPrefix();
+                    }
+
+                    switch (disasm.mnemonic) {
+                    case sh2::Mnemonic::NOP: drawNopMnemonic("nop"); break;
+                    case sh2::Mnemonic::SLEEP: drawMiscMnemonic("sleep"); break;
+                    case sh2::Mnemonic::MOV: drawLoadStoreMnemonic("mov"); break;
+                    case sh2::Mnemonic::MOVA: drawLoadStoreMnemonic("mova"); break;
+                    case sh2::Mnemonic::MOVT: drawLoadStoreMnemonic("movt"); break;
+                    case sh2::Mnemonic::CLRT: drawControlMnemonic("clrt"); break;
+                    case sh2::Mnemonic::SETT: drawControlMnemonic("sett"); break;
+                    case sh2::Mnemonic::EXTU: drawALUMnemonic("extu"); break;
+                    case sh2::Mnemonic::EXTS: drawALUMnemonic("exts"); break;
+                    case sh2::Mnemonic::SWAP: drawALUMnemonic("swap"); break;
+                    case sh2::Mnemonic::XTRCT: drawALUMnemonic("xtrct"); break;
+                    case sh2::Mnemonic::LDC: drawControlMnemonic("ldc"); break;
+                    case sh2::Mnemonic::LDS: drawControlMnemonic("lds"); break;
+                    case sh2::Mnemonic::STC: drawControlMnemonic("stc"); break;
+                    case sh2::Mnemonic::STS: drawControlMnemonic("sts"); break;
+                    case sh2::Mnemonic::ADD: drawALUMnemonic("add"); break;
+                    case sh2::Mnemonic::ADDC: drawALUMnemonic("addc"); break;
+                    case sh2::Mnemonic::ADDV: drawALUMnemonic("addv"); break;
+                    case sh2::Mnemonic::AND: drawALUMnemonic("and"); break;
+                    case sh2::Mnemonic::NEG: drawALUMnemonic("neg"); break;
+                    case sh2::Mnemonic::NEGC: drawALUMnemonic("negc"); break;
+                    case sh2::Mnemonic::NOT: drawALUMnemonic("not"); break;
+                    case sh2::Mnemonic::OR: drawALUMnemonic("or"); break;
+                    case sh2::Mnemonic::ROTCL: drawALUMnemonic("rotcl"); break;
+                    case sh2::Mnemonic::ROTCR: drawALUMnemonic("rotcr"); break;
+                    case sh2::Mnemonic::ROTL: drawALUMnemonic("rotl"); break;
+                    case sh2::Mnemonic::ROTR: drawALUMnemonic("rotr"); break;
+                    case sh2::Mnemonic::SHAL: drawALUMnemonic("shal"); break;
+                    case sh2::Mnemonic::SHAR: drawALUMnemonic("shar"); break;
+                    case sh2::Mnemonic::SHLL: drawALUMnemonic("shll"); break;
+                    case sh2::Mnemonic::SHLL2: drawALUMnemonic("shll2"); break;
+                    case sh2::Mnemonic::SHLL8: drawALUMnemonic("shll8"); break;
+                    case sh2::Mnemonic::SHLL16: drawALUMnemonic("shll16"); break;
+                    case sh2::Mnemonic::SHLR: drawALUMnemonic("shlr"); break;
+                    case sh2::Mnemonic::SHLR2: drawALUMnemonic("shlr2"); break;
+                    case sh2::Mnemonic::SHLR8: drawALUMnemonic("shlr8"); break;
+                    case sh2::Mnemonic::SHLR16: drawALUMnemonic("shlr16"); break;
+                    case sh2::Mnemonic::SUB: drawALUMnemonic("sub"); break;
+                    case sh2::Mnemonic::SUBC: drawALUMnemonic("subc"); break;
+                    case sh2::Mnemonic::SUBV: drawALUMnemonic("subv"); break;
+                    case sh2::Mnemonic::XOR: drawALUMnemonic("xor"); break;
+                    case sh2::Mnemonic::DT: drawALUMnemonic("dt"); break;
+                    case sh2::Mnemonic::CLRMAC: drawALUMnemonic("clrmac"); break;
+                    case sh2::Mnemonic::MAC: drawALUMnemonic("mac"); break;
+                    case sh2::Mnemonic::MUL: drawALUMnemonic("mul"); break;
+                    case sh2::Mnemonic::MULS: drawALUMnemonic("muls"); break;
+                    case sh2::Mnemonic::MULU: drawALUMnemonic("mulu"); break;
+                    case sh2::Mnemonic::DMULS: drawALUMnemonic("dmuls"); break;
+                    case sh2::Mnemonic::DMULU: drawALUMnemonic("dmulu"); break;
+                    case sh2::Mnemonic::DIV0S: drawALUMnemonic("div0s"); break;
+                    case sh2::Mnemonic::DIV0U: drawALUMnemonic("div0u"); break;
+                    case sh2::Mnemonic::DIV1: drawALUMnemonic("div1"); break;
+                    case sh2::Mnemonic::CMP_EQ:
+                        drawALUMnemonic("cmp");
+                        drawSeparator("/");
+                        drawCond("eq", getOp1() == getOp2());
+                        break;
+                    case sh2::Mnemonic::CMP_GE:
+                        drawALUMnemonic("cmp");
+                        drawSeparator("/");
+                        drawCond("ge", static_cast<sint32>(getOp1()) >= static_cast<sint32>(getOp2()));
+                        break;
+                    case sh2::Mnemonic::CMP_GT:
+                        drawALUMnemonic("cmp");
+                        drawSeparator("/");
+                        drawCond("gt", static_cast<sint32>(getOp1()) > static_cast<sint32>(getOp2()));
+                        break;
+                    case sh2::Mnemonic::CMP_HI:
+                        drawALUMnemonic("cmp");
+                        drawSeparator("/");
+                        drawCond("hi", getOp1() > getOp2());
+                        break;
+                    case sh2::Mnemonic::CMP_HS:
+                        drawALUMnemonic("cmp");
+                        drawSeparator("/");
+                        drawCond("hs", getOp1() >= getOp2());
+                        break;
+                    case sh2::Mnemonic::CMP_PL:
+                        drawALUMnemonic("cmp");
+                        drawSeparator("/");
+                        drawCond("pl", static_cast<sint32>(getOp1()) > 0);
+                        break;
+                    case sh2::Mnemonic::CMP_PZ:
+                        drawALUMnemonic("cmp");
+                        drawSeparator("/");
+                        drawCond("pz", static_cast<sint32>(getOp1()) >= 0);
+                        break;
+                    case sh2::Mnemonic::CMP_STR: //
+                    {
+                        const uint32 tmp = getOp1() ^ getOp2();
+                        const uint8 hh = tmp >> 24u;
+                        const uint8 hl = tmp >> 16u;
+                        const uint8 lh = tmp >> 8u;
+                        const uint8 ll = tmp >> 0u;
+                        drawALUMnemonic("cmp");
+                        drawSeparator("/");
+                        drawCond("str", !(hh && hl && lh && ll));
+                        break;
+                    }
+                    case sh2::Mnemonic::TAS: drawLoadStoreMnemonic("tas"); break;
+                    case sh2::Mnemonic::TST: drawALUMnemonic("tst"); break;
+                    case sh2::Mnemonic::BF:
+                        drawBranchMnemonic("b");
+                        drawCond("f", !probe.SR().T);
+                        break;
+                    case sh2::Mnemonic::BFS:
+                        drawBranchMnemonic("b");
+                        drawCond("f", !probe.SR().T);
+                        drawSeparator("/");
+                        drawBranchMnemonic("s");
+                        break;
+                    case sh2::Mnemonic::BT:
+                        drawBranchMnemonic("b");
+                        drawCond("t", probe.SR().T);
+                        break;
+                    case sh2::Mnemonic::BTS:
+                        drawBranchMnemonic("b");
+                        drawCond("t", probe.SR().T);
+                        drawSeparator("/");
+                        drawBranchMnemonic("s");
+                        break;
+                    case sh2::Mnemonic::BRA: drawBranchMnemonic("bra"); break;
+                    case sh2::Mnemonic::BRAF: drawBranchMnemonic("braf"); break;
+                    case sh2::Mnemonic::BSR: drawBranchMnemonic("bsr"); break;
+                    case sh2::Mnemonic::BSRF: drawBranchMnemonic("bsrf"); break;
+                    case sh2::Mnemonic::JMP: drawBranchMnemonic("jmp"); break;
+                    case sh2::Mnemonic::JSR: drawBranchMnemonic("jsr"); break;
+                    case sh2::Mnemonic::TRAPA: drawBranchMnemonic("trapa"); break;
+                    case sh2::Mnemonic::RTE: drawBranchMnemonic("rte"); break;
+                    case sh2::Mnemonic::RTS: drawBranchMnemonic("rts"); break;
+                    case sh2::Mnemonic::Illegal: drawIllegalMnemonic(); break;
+                    default: drawUnknownMnemonic(); break;
+                    }
+
+                    switch (disasm.opSize) {
+                    case sh2::OperandSize::Byte: drawSize("b"); break;
+                    case sh2::OperandSize::Word: drawSize("w"); break;
+                    case sh2::OperandSize::Long: drawSize("l"); break;
+                    default: break;
+                    }
+
+                    ImGui::SameLine(0, 0);
+                    const float endX = ImGui::GetCursorPosX();
+                    ImGui::SameLine(0, disasmCharSize.x * 10 - endX + startX);
+                    ImGui::Dummy(ImVec2(0, 0));
+                };
+
+                auto drawImm = [&](sint32 imm) {
+                    ImGui::TextColored(m_colors.disasm.immediate, "#0x%X", static_cast<uint32>(imm));
+                };
+
+                auto drawRegRead = [&](std::string_view regName) {
+                    ImGui::TextColored(m_colors.disasm.regRead, "%s", regName.data());
+                };
+
+                auto drawRegWrite = [&](std::string_view regName) {
+                    ImGui::TextColored(m_colors.disasm.regWrite, "%s", regName.data());
+                };
+
+                auto drawRegReadWrite = [&](std::string_view regName) {
+                    ImGui::TextColored(m_colors.disasm.regReadWrite, "%s", regName.data());
+                };
+
+                auto drawReg = [&](std::string_view regName, bool read, bool write) {
+                    if (read && write) {
+                        drawRegReadWrite(regName);
+                    } else if (write) {
+                        drawRegWrite(regName);
+                    } else {
+                        drawRegRead(regName);
+                    }
+                };
+
+                auto drawRnRead = [&](uint8 rn) { ImGui::TextColored(m_colors.disasm.regRead, "r%u", rn); };
+                auto drawRnWrite = [&](uint8 rn) { ImGui::TextColored(m_colors.disasm.regWrite, "r%u", rn); };
+                auto drawRnReadWrite = [&](uint8 rn) { ImGui::TextColored(m_colors.disasm.regReadWrite, "r%u", rn); };
+
+                auto drawRn = [&](uint8 rn, bool read, bool write) {
+                    if (read && write) {
+                        drawRnReadWrite(rn);
+                    } else if (write) {
+                        drawRnWrite(rn);
+                    } else {
+                        drawRnRead(rn);
+                    }
+                };
+
+                auto drawRWSymbol = [&](std::string_view symbol, bool write) {
+                    const auto color = write ? m_colors.disasm.regWrite : m_colors.disasm.regRead;
+                    ImGui::TextColored(color, "%s", symbol.data());
+                };
+
+                auto drawPlus = [&] { ImGui::TextColored(m_colors.disasm.addrInc, "+"); };
+                auto drawMinus = [&] { ImGui::TextColored(m_colors.disasm.addrDec, "-"); };
+                auto drawComma = [&] { ImGui::TextColored(m_colors.disasm.separator, ", "); };
+
+                auto drawOp = [&](const sh2::Operand &op) {
+                    if (op.type == sh2::Operand::Type::None) {
+                        return false;
+                    }
+
+                    switch (op.type) {
+                    case sh2::Operand::Type::Imm: drawImm(op.immDisp); break;
+                    case sh2::Operand::Type::Rn: drawRn(op.reg, op.read, op.write); break;
+                    case sh2::Operand::Type::AtRn:
+                        drawRWSymbol("@", op.write);
+                        ImGui::SameLine(0, 0);
+                        drawRnRead(op.reg);
+                        break;
+                    case sh2::Operand::Type::AtRnPlus:
+                        drawRWSymbol("@", op.write);
+                        ImGui::SameLine(0, 0);
+                        drawRnReadWrite(op.reg);
+                        ImGui::SameLine(0, 0);
+                        drawPlus();
+                        break;
+                    case sh2::Operand::Type::AtMinusRn:
+                        drawRWSymbol("@", op.write);
+                        ImGui::SameLine(0, 0);
+                        drawMinus();
+                        ImGui::SameLine(0, 0);
+                        drawRnReadWrite(op.reg);
+                        break;
+                    case sh2::Operand::Type::AtDispRn:
+                        drawRWSymbol("@(", op.write);
+                        ImGui::SameLine(0, 0);
+                        drawImm(op.immDisp);
+                        ImGui::SameLine(0, 0);
+                        drawComma();
+                        ImGui::SameLine(0, 0);
+                        drawRnRead(op.reg);
+                        ImGui::SameLine(0, 0);
+                        drawRWSymbol(")", op.write);
+                        break;
+                    case sh2::Operand::Type::AtR0Rn:
+                        drawRWSymbol("@(", op.write);
+                        ImGui::SameLine(0, 0);
+                        drawRnRead(0);
+                        ImGui::SameLine(0, 0);
+                        drawComma();
+                        ImGui::SameLine(0, 0);
+                        drawRnRead(op.reg);
+                        ImGui::SameLine(0, 0);
+                        drawRWSymbol(")", op.write);
+                        break;
+                    case sh2::Operand::Type::AtDispGBR:
+                        drawRWSymbol("@(", op.write);
+                        ImGui::SameLine(0, 0);
+                        drawImm(op.immDisp);
+                        ImGui::SameLine(0, 0);
+                        drawComma();
+                        ImGui::SameLine(0, 0);
+                        drawRegRead("gbr");
+                        ImGui::SameLine(0, 0);
+                        drawRWSymbol(")", op.write);
+                        break;
+                    case sh2::Operand::Type::AtR0GBR:
+                        drawRWSymbol("@(", op.write);
+                        ImGui::SameLine(0, 0);
+                        drawRnRead(0);
+                        ImGui::SameLine(0, 0);
+                        drawComma();
+                        ImGui::SameLine(0, 0);
+                        drawRegRead("gbr");
+                        ImGui::SameLine(0, 0);
+                        drawRWSymbol(")", op.write);
+                        break;
+                    case sh2::Operand::Type::AtDispPC:
+                        drawRWSymbol("@(", false);
+                        ImGui::SameLine(0, 0);
+                        drawImm(address + op.immDisp);
+                        ImGui::SameLine(0, 0);
+                        drawRWSymbol(")", false);
+                        break;
+                    case sh2::Operand::Type::AtDispPCWordAlign:
+                        drawRWSymbol("@(", false);
+                        ImGui::SameLine(0, 0);
+                        drawImm((address & ~3) + op.immDisp);
+                        ImGui::SameLine(0, 0);
+                        drawRWSymbol(")", false);
+                        break;
+                    case sh2::Operand::Type::AtRnPC:
+                        drawRWSymbol("@", op.write);
+                        ImGui::SameLine(0, 0);
+                        drawRnRead(op.reg);
+                        break;
+                    case sh2::Operand::Type::DispPC: drawImm(address + op.immDisp); break;
+                    case sh2::Operand::Type::RnPC: drawRnRead(op.reg); break;
+                    case sh2::Operand::Type::SR: drawReg("sr", op.read, op.write); break;
+                    case sh2::Operand::Type::GBR: drawReg("gbr", op.read, op.write); break;
+                    case sh2::Operand::Type::VBR: drawReg("vbr", op.read, op.write); break;
+                    case sh2::Operand::Type::MACH: drawReg("mach", op.read, op.write); break;
+                    case sh2::Operand::Type::MACL: drawReg("macl", op.read, op.write); break;
+                    case sh2::Operand::Type::PR: drawReg("pr", op.read, op.write); break;
+                    default: return false;
+                    }
+
+                    return true;
+                };
+
+                auto drawOp1 = [&] { return drawOp(disasm.op1); };
+                auto drawOp2 = [&] { return drawOp(disasm.op2); };
+
+                // -------------------------------------------------------------------------------------------------------------
+
+                ImGui::BeginGroup();
+                {
+                    drawHighlight();
+                    drawIcons();
                     drawAddress();
                     ImGui::SameLine(0.0f, m_style.disasmSpacing);
-                    drawOpcodeBytes(true);
+                    drawOpcodeBytes(m_settings.displayOpcodeBytes);
                     ImGui::SameLine(0.0f, m_style.disasmSpacing);
-                    drawOpcodeAscii(true);
-                    // ImGui::SameLine(0.0f, m_style.disasmSpacing);
+                    drawOpcodeAscii(m_settings.displayOpcodeAscii);
+                    ImGui::SameLine(0.0f, m_style.disasmSpacing);
                     drawInstruction();
                     if (disasm.op1.type != sh2::Operand::Type::None) {
                         ImGui::SameLine(0, 0);
@@ -844,148 +768,223 @@ void SH2DisassemblyView::Display() {
                         ImGui::SameLine(0, 0);
                         drawOp2();
                     }
+                    // TODO: show short annotations
+                    ImGui::SameLine(0, 0);
+                    ImGui::Dummy(ImVec2(ImGui::GetContentRegionAvail().x, lineHeight));
+                }
+                ImGui::EndGroup();
 
-                    ImGui::Separator();
+                if (lineHovered) {
+                    if (ImGui::BeginTooltip()) {
+                        drawAddress();
+                        ImGui::SameLine(0.0f, m_style.disasmSpacing);
+                        drawOpcodeBytes(true);
+                        ImGui::SameLine(0.0f, m_style.disasmSpacing);
+                        drawOpcodeAscii(true);
+                        // ImGui::SameLine(0.0f, m_style.disasmSpacing);
+                        drawInstruction();
+                        if (disasm.op1.type != sh2::Operand::Type::None) {
+                            ImGui::SameLine(0, 0);
+                            drawOp1();
+                        }
+                        if (disasm.op2.type != sh2::Operand::Type::None) {
+                            if (disasm.op1.type != sh2::Operand::Type::None) {
+                                ImGui::SameLine(0, 0);
+                                ImGui::TextColored(m_colors.disasm.separator, ", ");
+                            }
+                            ImGui::SameLine(0, 0);
+                            drawOp2();
+                        }
 
-                    auto notImmOrPC = [](sh2::Operand::Type opType) {
-                        return opType != sh2::Operand::Type::Imm && opType != sh2::Operand::Type::DispPC &&
-                               opType != sh2::Operand::Type::RnPC;
-                    };
-                    auto drawValue = [&](uint32 value) {
-                        ImGui::SameLine(0, 0);
-                        ImGui::TextColored(m_colors.disasm.separator, " = ");
-                        ImGui::SameLine(0, 0);
-                        drawImm(value);
-                    };
-                    auto drawRawRegs = [&](const sh2::Operand &op) {
-                        switch (op.type) {
-                        case sh2::Operand::Type::AtRn:
-                            drawRnRead(op.reg);
-                            drawValue(probe.R(op.reg));
+                        ImGui::Separator();
+
+                        auto notImmOrPC = [](sh2::Operand::Type opType) {
+                            return opType != sh2::Operand::Type::Imm && opType != sh2::Operand::Type::DispPC &&
+                                   opType != sh2::Operand::Type::RnPC;
+                        };
+                        auto drawValue = [&](uint32 value) {
+                            ImGui::SameLine(0, 0);
+                            ImGui::TextColored(m_colors.disasm.separator, " = ");
+                            ImGui::SameLine(0, 0);
+                            drawImm(value);
+                        };
+                        auto drawRawRegs = [&](const sh2::Operand &op) {
+                            switch (op.type) {
+                            case sh2::Operand::Type::AtRn:
+                                drawRnRead(op.reg);
+                                drawValue(probe.R(op.reg));
+                                break;
+                            case sh2::Operand::Type::AtRnPlus:
+                                drawRnReadWrite(op.reg);
+                                drawValue(probe.R(op.reg));
+                                break;
+                            case sh2::Operand::Type::AtMinusRn:
+                                drawRnReadWrite(op.reg);
+                                drawValue(probe.R(op.reg));
+                                break;
+                            case sh2::Operand::Type::AtDispRn:
+                                drawRnRead(op.reg);
+                                drawValue(probe.R(op.reg));
+
+                                drawImm(op.immDisp);
+                                ImGui::SameLine(0, 0);
+                                drawComma();
+                                ImGui::SameLine(0, 0);
+                                drawRnRead(op.reg);
+                                drawValue(probe.R(op.reg) + op.immDisp);
+                                break;
+                            case sh2::Operand::Type::AtR0Rn:
+                                drawRnRead(0);
+                                drawValue(probe.R(0));
+
+                                drawRnRead(op.reg);
+                                drawValue(probe.R(op.reg));
+
+                                drawRnRead(0);
+                                ImGui::SameLine(0, 0);
+                                drawComma();
+                                ImGui::SameLine(0, 0);
+                                drawRnRead(op.reg);
+                                drawValue(probe.R(op.reg) + probe.R(0));
+                                break;
+                            case sh2::Operand::Type::AtDispGBR:
+                                drawRegRead("gbr");
+                                drawValue(probe.GBR());
+
+                                drawImm(op.immDisp);
+                                ImGui::SameLine(0, 0);
+                                drawComma();
+                                ImGui::SameLine(0, 0);
+                                drawRegRead("gbr");
+                                drawValue(probe.GBR() + op.immDisp);
+                                break;
+                            case sh2::Operand::Type::AtR0GBR:
+                                drawRnRead(0);
+                                drawValue(probe.R(0));
+
+                                drawRegRead("gbr");
+                                drawValue(probe.GBR());
+
+                                drawRnRead(0);
+                                ImGui::SameLine(0, 0);
+                                drawComma();
+                                ImGui::SameLine(0, 0);
+                                drawRegRead("gbr");
+                                drawValue(probe.GBR() + probe.R(0));
+                                break;
+                            case sh2::Operand::Type::RnPC:
+                                drawRnRead(op.reg);
+                                drawValue(probe.R(op.reg));
+
+                                drawRnRead(op.reg);
+                                ImGui::SameLine(0, 0);
+                                drawSeparator("[");
+                                ImGui::SameLine(0, 0);
+                                drawPlus();
+                                ImGui::SameLine(0, 0);
+                                drawRegRead("pc");
+                                ImGui::SameLine(0, 0);
+                                drawSeparator("]");
+                                drawValue(probe.R(op.reg) + address);
+                                break;
+                            default: break;
+                            }
+                        };
+
+                        switch (disasm.mnemonic) {
+                        case sh2::Mnemonic::BF: [[fallthrough]];
+                        case sh2::Mnemonic::BFS: [[fallthrough]];
+                        case sh2::Mnemonic::BT: [[fallthrough]];
+                        case sh2::Mnemonic::BTS: [[fallthrough]];
+                        case sh2::Mnemonic::DT: [[fallthrough]];
+                        case sh2::Mnemonic::MOVT:
+                            drawRegRead("SR.T");
+                            drawValue(probe.SR().T);
                             break;
-                        case sh2::Operand::Type::AtRnPlus:
-                            drawRnReadWrite(op.reg);
-                            drawValue(probe.R(op.reg));
-                            break;
-                        case sh2::Operand::Type::AtMinusRn:
-                            drawRnReadWrite(op.reg);
-                            drawValue(probe.R(op.reg));
-                            break;
-                        case sh2::Operand::Type::AtDispRn:
-                            drawRnRead(op.reg);
-                            drawValue(probe.R(op.reg));
 
-                            drawImm(op.immDisp);
-                            ImGui::SameLine(0, 0);
-                            drawComma();
-                            ImGui::SameLine(0, 0);
-                            drawRnRead(op.reg);
-                            drawValue(probe.R(op.reg) + op.immDisp);
+                        case sh2::Mnemonic::DIV0S: [[fallthrough]];
+                        case sh2::Mnemonic::DIV0U: [[fallthrough]];
+                        case sh2::Mnemonic::DIV1:
+                            drawRegRead("SR.M");
+                            drawValue(probe.SR().M);
+                            drawRegRead("SR.Q");
+                            drawValue(probe.SR().Q);
+                            drawRegRead("SR.T");
+                            drawValue(probe.SR().T);
                             break;
-                        case sh2::Operand::Type::AtR0Rn:
-                            drawRnRead(0);
-                            drawValue(probe.R(0));
 
-                            drawRnRead(op.reg);
-                            drawValue(probe.R(op.reg));
-
-                            drawRnRead(0);
-                            ImGui::SameLine(0, 0);
-                            drawComma();
-                            ImGui::SameLine(0, 0);
-                            drawRnRead(op.reg);
-                            drawValue(probe.R(op.reg) + probe.R(0));
-                            break;
-                        case sh2::Operand::Type::AtDispGBR:
-                            drawRegRead("gbr");
-                            drawValue(probe.GBR());
-
-                            drawImm(op.immDisp);
-                            ImGui::SameLine(0, 0);
-                            drawComma();
-                            ImGui::SameLine(0, 0);
-                            drawRegRead("gbr");
-                            drawValue(probe.GBR() + op.immDisp);
-                            break;
-                        case sh2::Operand::Type::AtR0GBR:
-                            drawRnRead(0);
-                            drawValue(probe.R(0));
-
-                            drawRegRead("gbr");
-                            drawValue(probe.GBR());
-
-                            drawRnRead(0);
-                            ImGui::SameLine(0, 0);
-                            drawComma();
-                            ImGui::SameLine(0, 0);
-                            drawRegRead("gbr");
-                            drawValue(probe.GBR() + probe.R(0));
-                            break;
-                        case sh2::Operand::Type::RnPC:
-                            drawRnRead(op.reg);
-                            drawValue(probe.R(op.reg));
-
-                            drawRnRead(op.reg);
-                            ImGui::SameLine(0, 0);
-                            drawSeparator("[");
-                            ImGui::SameLine(0, 0);
-                            drawPlus();
-                            ImGui::SameLine(0, 0);
-                            drawRegRead("pc");
-                            ImGui::SameLine(0, 0);
-                            drawSeparator("]");
-                            drawValue(probe.R(op.reg) + address);
-                            break;
                         default: break;
                         }
-                    };
 
-                    switch (disasm.mnemonic) {
-                    case sh2::Mnemonic::BF: [[fallthrough]];
-                    case sh2::Mnemonic::BFS: [[fallthrough]];
-                    case sh2::Mnemonic::BT: [[fallthrough]];
-                    case sh2::Mnemonic::BTS: [[fallthrough]];
-                    case sh2::Mnemonic::DT: [[fallthrough]];
-                    case sh2::Mnemonic::MOVT:
-                        drawRegRead("SR.T");
-                        drawValue(probe.SR().T);
-                        break;
+                        drawRawRegs(disasm.op1);
+                        if (notImmOrPC(disasm.op1.type) && drawOp1()) {
+                            drawValue(getOp1());
+                        }
 
-                    case sh2::Mnemonic::DIV0S: [[fallthrough]];
-                    case sh2::Mnemonic::DIV0U: [[fallthrough]];
-                    case sh2::Mnemonic::DIV1:
-                        drawRegRead("SR.M");
-                        drawValue(probe.SR().M);
-                        drawRegRead("SR.Q");
-                        drawValue(probe.SR().Q);
-                        drawRegRead("SR.T");
-                        drawValue(probe.SR().T);
-                        break;
+                        drawRawRegs(disasm.op2);
+                        if (notImmOrPC(disasm.op2.type) && drawOp2()) {
+                            drawValue(getOp2());
+                        }
 
-                    default: break;
+                        // TODO: show detailed annotations
+
+                        ImGui::EndTooltip();
                     }
-
-                    drawRawRegs(disasm.op1);
-                    if (notImmOrPC(disasm.op1.type) && drawOp1()) {
-                        drawValue(getOp1());
-                    }
-
-                    drawRawRegs(disasm.op2);
-                    if (notImmOrPC(disasm.op2.type) && drawOp2()) {
-                        drawValue(getOp2());
-                    }
-
-                    // TODO: show detailed annotations
-
-                    ImGui::EndTooltip();
                 }
-            }
             }
         }
         ImGui::PopFont();
-        m_state.lastScrollY = ImGui::GetScrollY();
     }
     ImGui::EndChild();
+}
+
+void SH2DisassemblyView::ScrollToAddress(uint32 targetAddress, float viewHeight, bool smoothFollow) {
+    const uint32 clampedAddress = std::clamp(targetAddress, m_state.minAddress, m_state.maxAddress);
+    const uint32 lineIndex = (clampedAddress - m_state.minAddress) / sizeof(uint16);
+    const float lineTop = m_lineAdvance * static_cast<float>(lineIndex);
+    const float currentScroll = ImGui::GetScrollY();
+
+    // Calculate target scroll position (center the line)
+    const float lineCenter = lineTop + m_lineAdvance * 0.5f;
+    const float targetY = lineCenter - viewHeight * 0.5f;
+    const float clampedY = std::clamp(targetY, 0.0f, ImGui::GetScrollMaxY());
+    const float distance = clampedY - currentScroll;
+    const float absDistance = std::abs(distance);
+
+    if (smoothFollow) {
+        // Smooth follow mode: keep PC in comfortable viewing zone (middle 50%)
+        const float topMargin = viewHeight * 0.25f;
+        const float bottomMargin = viewHeight * 0.75f;
+        const float linePositionInView = lineTop - currentScroll;
+
+        // Check if line is outside the comfortable zone
+        if (linePositionInView >= topMargin && linePositionInView <= bottomMargin) {
+            m_state.jumpRequested = false;
+            return;
+        }
+
+        // Instant jump if very far away (snappy for large PC jumps)
+        if (absDistance > viewHeight * 2.0f) {
+            ImGui::SetScrollY(clampedY);
+            m_state.jumpRequested = false;
+            return;
+        }
+
+        // Smooth scroll toward target
+        const float step = distance * 0.3f;
+        ImGui::SetScrollY(currentScroll + step);
+        m_state.jumpRequested = false;
+    } else {
+        // Jump mode (explicit JumpTo request): smooth scroll to exact center
+        if (absDistance <= 1.0f) {
+            ImGui::SetScrollY(clampedY);
+            m_state.jumpRequested = false;
+        } else {
+            const float step = distance * 0.25f;
+            ImGui::SetScrollY(currentScroll + step);
+            m_state.jumpRequested = true;
+        }
+    }
 }
 
 } // namespace app::ui

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.cpp
@@ -26,6 +26,19 @@ void SH2DisassemblyView::JumpTo(uint32 address) {
     m_state.jumpRequested = true;
 }
 
+bool SH2DisassemblyView::IsFollowPCEnabled() const {
+    return m_state.followPC;
+}
+
+void SH2DisassemblyView::SetFollowPCEnabled(bool enabled) {
+    m_state.followPC = enabled;
+    if (enabled) {
+        JumpTo(m_sh2.GetProbe().PC());
+    } else {
+        m_state.jumpRequested = false;
+    }
+}
+
 void SH2DisassemblyView::Display() {
     if (ImGui::BeginMenuBar()) {
         if (ImGui::BeginMenu("View")) {

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.hpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.hpp
@@ -109,16 +109,22 @@ private:
         bool colorizeMnemonicsByType = true;
     } m_settings;
 
-    // state struct used for scrollable disassembly view
-    // TODO: maybe move parts into m_settings?
+    // State struct used for scrollable disassembly view
     struct State {
         uint32 minAddress = kAddressMin;
-        uint32 maxAddress = kAddressMax;    // address range min:max
-        uint32 jumpAddress = 0;             // address to jump to, zero initialized
-        bool jumpRequested = false;         // jump request
-        bool followPC = true;               // follow PC
-        float lastScrollY = 0.0f;           // last scroll position
+        uint32 maxAddress = kAddressMax; // address range min:max
+        uint32 jumpAddress = 0;          // address to jump to
+        bool jumpRequested = false;      // pending jump request
+        bool followPC = true;            // auto-follow PC toggle
     } m_state;
+
+    // Cached line height, computed dynamically from font size
+    float m_lineAdvance = 0.0f;
+
+    // Scrolls the disassembly view to center the given address.
+    // smoothFollow: true for continuous PC tracking (smooth local, snappy far)
+    //               false for explicit JumpTo requests (always smooth)
+    void ScrollToAddress(uint32 targetAddress, float viewHeight, bool smoothFollow);
 };
 
 } // namespace app::ui

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.hpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <app/shared_context.hpp>
+#include <app/ui/views/debug/sh2_debugger_model.hpp>
 
 #include <imgui.h>
 
@@ -8,16 +9,15 @@ namespace app::ui {
 
 class SH2DisassemblyView {
 public:
-    SH2DisassemblyView(SharedContext &context, ymir::sh2::SH2 &sh2);
+    SH2DisassemblyView(SharedContext &context, ymir::sh2::SH2 &sh2, SH2DebuggerModel &model);
 
     void Display();
     void JumpTo(uint32 address);
-    bool IsFollowPCEnabled() const;
-    void SetFollowPCEnabled(bool enabled);
 
 private:
     SharedContext &m_context;
     ymir::sh2::SH2 &m_sh2;
+    SH2DebuggerModel &m_model;
 
     static constexpr uint32 kAddressMin = 0x00000000u;
     static constexpr uint32 kAddressMax = 0xFFFFFFFEu; // Full 32-bit SH-2 address space (even aligned)
@@ -109,14 +109,11 @@ private:
         bool colorizeMnemonicsByType = true;
     } m_settings;
 
-    // State struct used for scrollable disassembly view
-    struct State {
+    // View-local state for scrollable disassembly view
+    struct ViewState {
         uint32 minAddress = kAddressMin;
         uint32 maxAddress = kAddressMax; // address range min:max
-        uint32 jumpAddress = 0;          // address to jump to
-        bool jumpRequested = false;      // pending jump request
-        bool followPC = true;            // auto-follow PC toggle
-    } m_state;
+    } m_viewState;
 
     // Cached line height, computed dynamically from font size
     float m_lineAdvance = 0.0f;

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.hpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.hpp
@@ -113,6 +113,7 @@ private:
     struct ViewState {
         uint32 minAddress = kAddressMin;
         uint32 maxAddress = kAddressMax; // address range min:max
+        bool rangeChanged = false;       // true if range updated this frame
     } m_viewState;
 
     // Cached line height, computed dynamically from font size

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.hpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.hpp
@@ -11,7 +11,9 @@ public:
     SH2DisassemblyView(SharedContext &context, ymir::sh2::SH2 &sh2);
 
     void Display();
-    void JumpTo(uint32 address);    // jump to address helper
+    void JumpTo(uint32 address);
+    bool IsFollowPCEnabled() const;
+    void SetFollowPCEnabled(bool enabled);
 
 private:
     SharedContext &m_context;

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.hpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.hpp
@@ -11,10 +11,14 @@ public:
     SH2DisassemblyView(SharedContext &context, ymir::sh2::SH2 &sh2);
 
     void Display();
+    void JumpTo(uint32 address);    // jump to address helper
 
 private:
     SharedContext &m_context;
     ymir::sh2::SH2 &m_sh2;
+
+    static constexpr uint32 kAddressMin = 0x00000000u;
+    static constexpr uint32 kAddressMax = 0x07FFFFFEu; // SH-2 main address space/range (even aligned)
 
     struct Colors {
 #define C(r, g, b) (r / 255.0f), (g / 255.0f), (b / 255.0f), 1.0f
@@ -102,6 +106,17 @@ private:
 
         bool colorizeMnemonicsByType = true;
     } m_settings;
+
+    // state struct used for scrollable disassembly view
+    // TODO: maybe move parts into m_settings?
+    struct State {
+        uint32 minAddress = kAddressMin;
+        uint32 maxAddress = kAddressMax;    // address range min:max
+        uint32 jumpAddress = 0;             // address to jump to, zero initialized
+        bool jumpRequested = false;         // jump request
+        bool followPC = true;               // follow PC
+        float lastScrollY = 0.0f;           // last scroll position
+    } m_state;
 };
 
 } // namespace app::ui

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.hpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.hpp
@@ -20,7 +20,7 @@ private:
     ymir::sh2::SH2 &m_sh2;
 
     static constexpr uint32 kAddressMin = 0x00000000u;
-    static constexpr uint32 kAddressMax = 0x07FFFFFEu; // SH-2 main address space/range (even aligned)
+    static constexpr uint32 kAddressMax = 0xFFFFFFFEu; // Full 32-bit SH-2 address space (even aligned)
 
     struct Colors {
 #define C(r, g, b) (r / 255.0f), (g / 255.0f), (b / 255.0f), 1.0f

--- a/apps/ymir-sdl3/src/app/ui/windows/debug/sh2_debugger_window.cpp
+++ b/apps/ymir-sdl3/src/app/ui/windows/debug/sh2_debugger_window.cpp
@@ -14,8 +14,8 @@ namespace app::ui {
 
 SH2DebuggerWindow::SH2DebuggerWindow(SharedContext &context, bool master)
     : SH2WindowBase(context, master)
-    , m_disasmView(context, m_sh2)
-    , m_toolbarView(context, m_sh2, m_disasmView)
+    , m_disasmView(context, m_sh2, m_debuggerModel)
+    , m_toolbarView(context, m_sh2, m_debuggerModel)
     , m_regsView(context, m_sh2) {
 
     m_windowConfig.name = fmt::format("{}SH2 debugger", master ? 'M' : 'S');

--- a/apps/ymir-sdl3/src/app/ui/windows/debug/sh2_debugger_window.cpp
+++ b/apps/ymir-sdl3/src/app/ui/windows/debug/sh2_debugger_window.cpp
@@ -14,9 +14,9 @@ namespace app::ui {
 
 SH2DebuggerWindow::SH2DebuggerWindow(SharedContext &context, bool master)
     : SH2WindowBase(context, master)
-    , m_toolbarView(context, m_sh2)
-    , m_regsView(context, m_sh2)
-    , m_disasmView(context, m_sh2) {
+    , m_disasmView(context, m_sh2)
+    , m_toolbarView(context, m_sh2, m_disasmView)
+    , m_regsView(context, m_sh2) {
 
     m_windowConfig.name = fmt::format("{}SH2 debugger", master ? 'M' : 'S');
     m_windowConfig.flags = ImGuiWindowFlags_MenuBar;

--- a/apps/ymir-sdl3/src/app/ui/windows/debug/sh2_debugger_window.hpp
+++ b/apps/ymir-sdl3/src/app/ui/windows/debug/sh2_debugger_window.hpp
@@ -20,9 +20,9 @@ protected:
     void DrawContents() override;
 
 private:
+    SH2DisassemblyView m_disasmView;
     SH2DebugToolbarView m_toolbarView;
     SH2RegistersView m_regsView;
-    SH2DisassemblyView m_disasmView;
 };
 
 } // namespace app::ui

--- a/apps/ymir-sdl3/src/app/ui/windows/debug/sh2_debugger_window.hpp
+++ b/apps/ymir-sdl3/src/app/ui/windows/debug/sh2_debugger_window.hpp
@@ -3,6 +3,7 @@
 #include "sh2_window_base.hpp"
 
 #include <app/ui/views/debug/sh2_debug_toolbar_view.hpp>
+#include <app/ui/views/debug/sh2_debugger_model.hpp>
 #include <app/ui/views/debug/sh2_disassembly_view.hpp>
 #include <app/ui/views/debug/sh2_registers_view.hpp>
 
@@ -20,6 +21,7 @@ protected:
     void DrawContents() override;
 
 private:
+    SH2DebuggerModel m_debuggerModel;
     SH2DisassemblyView m_disasmView;
     SH2DebugToolbarView m_toolbarView;
     SH2RegistersView m_regsView;


### PR DESCRIPTION
# SH-2 Debugger: Improve Scrolling & Disassembly Dump

## Summary
Converts the SH-2 disassembly view from a static display to a fully scrollable interface with "Follow PC" toggle and adds a disassembly dump feature with game-identified filenames.

## Changes

_Scrollable Disassembly View_
- Replaced static view with scrollable interface (mouse wheel or scrollbar)
- PC tracking follows execution by default with smooth scrolling
- Added "Follow PC" toggle button to switch between auto-follow and manual navigation
- Implemented comfort zone algorithm: keeps PC visible in middle 50% of viewport
- Smooth easing (30%) for local PC changes, instant snap for far jumps (>2x viewport)
- Dynamic line height calculation for proper DPI/font scaling support
<img width="1624" height="1060" alt="debug_view" src="https://github.com/user-attachments/assets/ae9edbd9-8aed-47b6-a856-4a229c869926" />


_Disassembly Dump Feature_
New popup window (`SH2DisasmDumpView`) for dumping memory ranges:
- Configure hex address range (start/end)
- Choose dump mode: formatted disassembly, raw binary, or both
- Result written to profile dumps directory
<img width="1624" height="1060" alt="disasm_dump" src="https://github.com/user-attachments/assets/3ad90235-a5eb-421a-81f5-9ae72bb6cbdd" />


Enhanced filenames with game identification:
- Before: `msh2-disasm_06004000_06005000.txt`
- After: `msh2-disasm_06004000_06005000_GS-9037_SAKURA_TAISEN.txt`
- Includes product number (max 16 chars) and sanitized game title (max 32 chars)
- Filesystem-safe sanitization (alphanumeric + -_ only)
- Fallback to NoDisc/NoGame when no disc loaded

New event (`DumpDisasmView`) handles:
- Address alignment and bounds clamping
- Formatted disassembly output using ymir::sh2::Disassemble
- Optional raw binary dump
- Directory creation and error handling

_Integration_
- Added "Follow PC" toggle to SH-2 debug toolbar
- Added "Dump Disasm Range" button to SH-2 debug toolbar
- Both buttons use Material Icons for consistency

https://github.com/user-attachments/assets/a034f04c-b432-4510-a0a1-c4b4e49a4ea9


## Testing
- Build: All targets compile successfully
- Manual - Scrolling: Verified smooth behavior for local PC steps, instant jumps for far changes
- Manual - Follow PC: Toggle works correctly, user scroll disables auto-follow as expected
- Manual - Dump popup: UI interaction tested, address validation working
- Manual - Dump output: Verified both text and binary dumps with game-identified filenames

## Technical Details
_Scrolling Algorithm_
The comfort zone approach uses percentage-based margins instead of line counts:
```cpp
// Keep PC within middle 50% of viewport
const float topMargin = viewHeight * 0.25f;
const float bottomMargin = viewHeight * 0.75f;
const float linePositionInView = lineTop - currentScroll;

// Only scroll if PC outside comfort zone
if (linePositionInView >= topMargin && linePositionInView <= bottomMargin) {
    return; // PC is comfortably visible
}

// Instant jump for far distances (>2x viewport)
if (absDistance > viewHeight * 2.0f) {
    ImGui::SetScrollY(targetY);
} else {
    // Smooth easing for nearby changes
    ImGui::SetScrollY(currentScroll + distance * 0.3f);
}
```
_Dump Implementation_
Disassembly formatting uses a three-lambda approach:
- `mnemonicToString`: Converts mnemonic enum to string view
- `opToString`: Formats operand strings with colorization hints
- `instrToString`: Assembles complete instruction line
Binary dumps write raw big-endian uint16 opcodes for external analysis tools.

## Impact
- **Improved debugging workflow**: Navigate freely through disassembly while maintaining PC visibility
- **Better dump organization**: Files self-document with game identification
- **Enhanced productivity**: Quick memory range dumps for analysis
- **Robustness**: Dynamic font sizing, safe filename handling, proper error reporting