### PR TITLE
build: Update FreeBSD CI to 15.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -196,14 +196,14 @@ jobs:
 
       # TODO: configure vcpkg cache
 
-      - uses: cross-platform-actions/action@v0.29.0
+      - uses: cross-platform-actions/action@v0.32.0
         env:
           CXX: clang++21
           CC: clang21
         with:
           operating_system: freebsd
           architecture: ${{ matrix.arch.name }}
-          version: '14.3'
+          version: '15.0'
           environment_variables: CXX CC
           run: |
             sudo pkg upgrade -y


### PR DESCRIPTION
FreeBSD 15.0-RELEASE is the most recent release version, therefore update the CI to this version. Support for FreeBSD 15.0 was added to `cross-platform-actions/action` in version `0.31.0`, and `0.32.0` is the latest release.