### PR TITLE
Fixed D-Pad axis, would overwrite whenever an input was released in opposite direction

### DIFF
--- a/apps/ymir-sdl3/src/app/app.cpp
+++ b/apps/ymir-sdl3/src/app/app.cpp
@@ -2227,6 +2227,7 @@ void App::RunEmulator() {
                         settings.video.fullScreen = !settings.video.fullScreen;
                         settings.MakeDirty();
                     }
+
                 }
                 if (!io.WantCaptureMouse || inputContext.IsCapturing()) {
                     if (evt.button.which != SDL_PEN_MOUSEID && evt.button.which != SDL_TOUCH_MOUSEID) {

--- a/apps/ymir-sdl3/src/app/app.cpp
+++ b/apps/ymir-sdl3/src/app/app.cpp
@@ -2227,7 +2227,6 @@ void App::RunEmulator() {
                         settings.video.fullScreen = !settings.video.fullScreen;
                         settings.MakeDirty();
                     }
-
                 }
                 if (!io.WantCaptureMouse || inputContext.IsCapturing()) {
                     if (evt.button.which != SDL_PEN_MOUSEID && evt.button.which != SDL_TOUCH_MOUSEID) {

--- a/apps/ymir-sdl3/src/app/input/input_context.cpp
+++ b/apps/ymir-sdl3/src/app/input/input_context.cpp
@@ -165,30 +165,31 @@ void InputContext::ProcessPrimitive(uint32 id, GamepadButton button, bool presse
         case GamepadButton::DpadLeft:
             ProcessPrimitive(
                 id, GamepadAxis1D::DPadX,
-                pressed ? -1.0f :
-                (m_gamepadButtonStates[id][static_cast<size_t>(GamepadButton::DpadRight)] ? +1.0 : 0.0f)); 
-            break; 
+                pressed ? -1.0f
+                        : (m_gamepadButtonStates[id][static_cast<size_t>(GamepadButton::DpadRight)] ? +1.0f : 0.0f));
+            break;
 
-        case GamepadButton::DpadRight: 
+        case GamepadButton::DpadRight:
             ProcessPrimitive(
                 id, GamepadAxis1D::DPadX,
-                pressed ? +1.0f :
-                (m_gamepadButtonStates[id][static_cast<size_t>(GamepadButton::DpadRight)] ? -1.0 : 0.0f));
+                pressed ? +1.0f
+                        : (m_gamepadButtonStates[id][static_cast<size_t>(GamepadButton::DpadLeft)] ? -1.0f : 0.0f));
             break;
 
-        case GamepadButton::DpadUp: 
+        case GamepadButton::DpadUp:
             ProcessPrimitive(
                 id, GamepadAxis1D::DPadY,
-                pressed ? -1.0f :
-                (m_gamepadButtonStates[id][static_cast<size_t>(GamepadButton::DpadUp)] ? +1.0 : 0.0f));
+                pressed ? -1.0f
+                        : (m_gamepadButtonStates[id][static_cast<size_t>(GamepadButton::DpadDown)] ? +1.0f : 0.0f));
             break;
 
-        case GamepadButton::DpadDown: ProcessPrimitive(
-                id, GamepadAxis1D::DPadY, 
-                pressed ? +1.0f :
-                (m_gamepadButtonStates[id][static_cast<size_t>(GamepadButton::DpadDown)] ? -1.0f : 0.0f)); 
+        case GamepadButton::DpadDown:
+            ProcessPrimitive(
+                id, GamepadAxis1D::DPadY,
+                pressed ? +1.0f
+                        : (m_gamepadButtonStates[id][static_cast<size_t>(GamepadButton::DpadUp)] ? -1.0f : 0.0f));
             break;
-        
+
         default: break;
         }
     }

--- a/apps/ymir-sdl3/src/app/input/input_context.cpp
+++ b/apps/ymir-sdl3/src/app/input/input_context.cpp
@@ -161,33 +161,29 @@ void InputContext::ProcessPrimitive(uint32 id, GamepadButton button, bool presse
 
         // Convert D-Pad buttons into axis primitives
         // Preserves the opposite direction if still pressed when releasing D-pad Input
-        switch (button) {
-        case GamepadButton::DpadLeft:
-            ProcessPrimitive(
-                id, GamepadAxis1D::DPadX,
-                pressed ? -1.0f
-                        : (m_gamepadButtonStates[id][static_cast<size_t>(GamepadButton::DpadRight)] ? +1.0f : 0.0f));
+        auto convertDpad = [&](GamepadAxis1D axis, GamepadButton oppositeButton, float value) {
+            const auto btnIndex = static_cast<size_t>(oppositeButton);
+
+            if (pressed) {
+                ProcessPrimitive(id, axis, value);
+            } else if (m_gamepadButtonStates[id][btnIndex]) {
+                ProcessPrimitive(id, axis, -value);
+            } else {
+                ProcessPrimitive(id, axis, 0.0f);
+            }
+        };
+        switch (button)
+        {
+        case GamepadButton::DpadLeft: convertDpad(GamepadAxis1D::DPadX, GamepadButton::DpadRight, -1.0f);
             break;
 
-        case GamepadButton::DpadRight:
-            ProcessPrimitive(
-                id, GamepadAxis1D::DPadX,
-                pressed ? +1.0f
-                        : (m_gamepadButtonStates[id][static_cast<size_t>(GamepadButton::DpadLeft)] ? -1.0f : 0.0f));
+        case GamepadButton::DpadRight: convertDpad(GamepadAxis1D::DPadX, GamepadButton::DpadLeft, +1.0f);
             break;
 
-        case GamepadButton::DpadUp:
-            ProcessPrimitive(
-                id, GamepadAxis1D::DPadY,
-                pressed ? -1.0f
-                        : (m_gamepadButtonStates[id][static_cast<size_t>(GamepadButton::DpadDown)] ? +1.0f : 0.0f));
+        case GamepadButton::DpadUp: convertDpad(GamepadAxis1D::DPadY, GamepadButton::DpadDown, -1.0f); 
             break;
 
-        case GamepadButton::DpadDown:
-            ProcessPrimitive(
-                id, GamepadAxis1D::DPadY,
-                pressed ? +1.0f
-                        : (m_gamepadButtonStates[id][static_cast<size_t>(GamepadButton::DpadUp)] ? -1.0f : 0.0f));
+        case GamepadButton::DpadDown: convertDpad(GamepadAxis1D::DPadY, GamepadButton::DpadUp, +1.0f);
             break;
 
         default: break;

--- a/apps/ymir-sdl3/src/app/input/input_context.cpp
+++ b/apps/ymir-sdl3/src/app/input/input_context.cpp
@@ -160,11 +160,35 @@ void InputContext::ProcessPrimitive(uint32 id, GamepadButton button, bool presse
         ProcessEvent({.element = {id, button}, .buttonPressed = pressed});
 
         // Convert D-Pad buttons into axis primitives
+        // Preserves the opposite direction if still pressed when releasing D-pad Input
         switch (button) {
-        case GamepadButton::DpadLeft: ProcessPrimitive(id, GamepadAxis1D::DPadX, pressed ? -1.0f : 0.0f); break;
-        case GamepadButton::DpadRight: ProcessPrimitive(id, GamepadAxis1D::DPadX, pressed ? +1.0f : 0.0f); break;
-        case GamepadButton::DpadUp: ProcessPrimitive(id, GamepadAxis1D::DPadY, pressed ? -1.0f : 0.0f); break;
-        case GamepadButton::DpadDown: ProcessPrimitive(id, GamepadAxis1D::DPadY, pressed ? +1.0f : 0.0f); break;
+        case GamepadButton::DpadLeft:
+            ProcessPrimitive(
+                id, GamepadAxis1D::DPadX,
+                pressed ? -1.0f :
+                (m_gamepadButtonStates[id][static_cast<size_t>(GamepadButton::DpadRight)] ? +1.0 : 0.0f)); 
+            break; 
+
+        case GamepadButton::DpadRight: 
+            ProcessPrimitive(
+                id, GamepadAxis1D::DPadX,
+                pressed ? +1.0f :
+                (m_gamepadButtonStates[id][static_cast<size_t>(GamepadButton::DpadRight)] ? -1.0 : 0.0f));
+            break;
+
+        case GamepadButton::DpadUp: 
+            ProcessPrimitive(
+                id, GamepadAxis1D::DPadY,
+                pressed ? -1.0f :
+                (m_gamepadButtonStates[id][static_cast<size_t>(GamepadButton::DpadUp)] ? +1.0 : 0.0f));
+            break;
+
+        case GamepadButton::DpadDown: ProcessPrimitive(
+                id, GamepadAxis1D::DPadY, 
+                pressed ? +1.0f :
+                (m_gamepadButtonStates[id][static_cast<size_t>(GamepadButton::DpadDown)] ? -1.0f : 0.0f)); 
+            break;
+        
         default: break;
         }
     }


### PR DESCRIPTION
Releasing one D-Pad direction would previously reset the axis to 0 even if the opposite direction was still held. Causing quick direction changes (left to right to left) to drop the final input. This fix will preserve the opposite direction input when it remains pressed.

I did some indentation changes as well, let me know if this is too much white space between each case or if there is anything else that can be done to my code. Thank you!