### PR TITLE
fix(SCU): remove s64 from Reg48, use u64 consistently

### DIFF
--- a/libs/ymir-core/include/ymir/hw/scu/scu_dsp.hpp
+++ b/libs/ymir-core/include/ymir/hw/scu/scu_dsp.hpp
@@ -156,7 +156,7 @@ public:
         sign = static_cast<sint64>(result << 16ull) < 0;
         carry = bit::test<48>(result);
         overflow |= bit::test<47>((~(op1 ^ op2)) & (op1 ^ result));
-        ALU.s64 = bit::extract<0, 47>(result);
+        ALU.u64 = bit::extract<0, 47>(result);
     }
 
     FORCE_INLINE void ALU_SR() {
@@ -239,7 +239,7 @@ public:
             break;
         }
         case 0b0100: RX = value; break;
-        case 0b0101: P.s64 = bit::extract<0, 47>(static_cast<sint64>(static_cast<sint32>(value))); break;
+        case 0b0101: P.u64 = bit::extract<0, 47>(static_cast<sint64>(static_cast<sint32>(value))); break;
         case 0b0110: dmaReadAddr = (value << 2u) & 0x7FF'FFFC; break;
         case 0b0111: dmaWriteAddr = (value << 2u) & 0x7FF'FFFC; break;
         case 0b1010: loopCount = value & 0xFFF; break;
@@ -272,7 +272,7 @@ public:
             break;
         }
         case 0b0100: RX = value; break;
-        case 0b0101: P.s64 = bit::extract<0, 47>(static_cast<sint64>(static_cast<sint32>(value))); break;
+        case 0b0101: P.u64 = bit::extract<0, 47>(static_cast<sint64>(static_cast<sint32>(value))); break;
         case 0b0110: dmaReadAddr = (value << 2u) & 0x7FF'FFFC; break;
         case 0b0111: dmaWriteAddr = (value << 2u) & 0x7FF'FFFC; break;
         case 0b1010: loopCount = value & 0xFFF; break;
@@ -356,7 +356,6 @@ public:
 
     union Reg48 {
         uint64 u64;
-        sint64 s64;
         struct {
             uint32 L;
             uint16 u16Top;

--- a/libs/ymir-core/src/ymir/hw/scu/scu_dsp.cpp
+++ b/libs/ymir-core/src/ymir/hw/scu/scu_dsp.cpp
@@ -398,14 +398,14 @@ FORCE_INLINE void SCUDSP::Cmd_Operation(DSPInstr instr) {
     //  111   MOV [s],P   MOV [s],X
     if ((instr.aluInfo.xBusOp & 0b11) == 0b10) {
         // MOV MUL,P
-        P.s64 = bit::extract<0, 47>(static_cast<sint64>(RX) * static_cast<sint64>(RY));
+        P.u64 = bit::extract<0, 47>(static_cast<sint64>(RX) * static_cast<sint64>(RY));
     }
     if (instr.aluInfo.xBusOp >= 0b011) {
         const sint32 value = ReadSource<debug>(instr.aluInfo.xBusSource);
         markDataRAMRead(instr.aluInfo.xBusSource);
         if ((instr.aluInfo.xBusOp & 0b11) == 0b11) {
             // MOV [s],P
-            P.s64 = bit::extract<0, 47>(static_cast<sint64>(value));
+            P.u64 = bit::extract<0, 47>(static_cast<sint64>(value));
         }
         if (bit::test<2>(instr.aluInfo.xBusOp)) {
             // MOV [s],X
@@ -428,17 +428,17 @@ FORCE_INLINE void SCUDSP::Cmd_Operation(DSPInstr instr) {
     // 111    MOV [s],A   MOV [s],Y
     if ((instr.aluInfo.yBusOp & 0b11) == 0b01) {
         // CLR A
-        AC.s64 = 0;
+        AC.u64 = 0;
     } else if ((instr.aluInfo.yBusOp & 0b11) == 0b10) {
         // MOV ALU,A
-        AC.s64 = ALU.s64;
+        AC.u64 = ALU.u64;
     }
     if (instr.aluInfo.yBusOp >= 0b11) {
         const sint32 value = ReadSource<debug>(instr.aluInfo.yBusSource);
         markDataRAMRead(instr.aluInfo.yBusSource);
         if ((instr.aluInfo.yBusOp & 0b11) == 0b11) {
             // MOV [s],A
-            AC.s64 = bit::extract<0, 47>(static_cast<sint64>(value));
+            AC.u64 = bit::extract<0, 47>(static_cast<sint64>(value));
         }
         if (bit::test<2>(instr.aluInfo.yBusOp)) {
             // MOV [s],Y

--- a/tests/ymir-core-tests/src/hw/scu/scu_dsp_tests.cpp
+++ b/tests/ymir-core-tests/src/hw/scu/scu_dsp_tests.cpp
@@ -368,11 +368,11 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP ALU operations compute correc
             dsp.carry = true;
             dsp.overflow = false;
 
-            dsp.AC.L = -123;
+            dsp.AC.L = 0xFFFFFF85; // -123
             dsp.P.L = 1;
             dsp.ALU_ADD();
 
-            CHECK(dsp.ALU.L == -122);
+            CHECK(dsp.ALU.L == 0xFFFFFF86); // -122
             CHECK(dsp.zero == false);
             CHECK(dsp.sign == true);
             CHECK(dsp.carry == false);
@@ -385,11 +385,11 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP ALU operations compute correc
             dsp.carry = false;
             dsp.overflow = false;
 
-            dsp.AC.L = -123;
-            dsp.P.L = -1;
+            dsp.AC.L = 0xFFFFFF85; // -123
+            dsp.P.L = 0xFFFFFFFF;  // -1
             dsp.ALU_ADD();
 
-            CHECK(dsp.ALU.L == -124);
+            CHECK(dsp.ALU.L == 0xFFFFFF84); // -124
             CHECK(dsp.zero == false);
             CHECK(dsp.sign == true);
             CHECK(dsp.carry == true);
@@ -420,7 +420,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP ALU operations compute correc
             dsp.overflow = false;
 
             dsp.AC.L = 100;
-            dsp.P.L = -1;
+            dsp.P.L = 0xFFFFFFFF; // -1
             dsp.ALU_ADD();
 
             CHECK(dsp.ALU.L == 99);
@@ -437,7 +437,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP ALU operations compute correc
             dsp.overflow = false;
 
             dsp.AC.L = 0x80000000;
-            dsp.P.L = -1;
+            dsp.P.L = 0xFFFFFFFF; // -1
             dsp.ALU_ADD();
 
             CHECK(dsp.ALU.L == 0x7FFFFFFF);
@@ -528,11 +528,11 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP ALU operations compute correc
             dsp.carry = true;
             dsp.overflow = false;
 
-            dsp.AC.L = -123;
+            dsp.AC.L = 0xFFFFFF85; // -123
             dsp.P.L = 1;
             dsp.ALU_SUB();
 
-            CHECK(dsp.ALU.L == -124);
+            CHECK(dsp.ALU.L == 0xFFFFFF84); // -124
             CHECK(dsp.zero == false);
             CHECK(dsp.sign == true);
             CHECK(dsp.carry == false);
@@ -549,7 +549,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP ALU operations compute correc
             dsp.P.L = 123;
             dsp.ALU_SUB();
 
-            CHECK(dsp.ALU.L == -122);
+            CHECK(dsp.ALU.L == 0xFFFFFF86); // -122
             CHECK(dsp.zero == false);
             CHECK(dsp.sign == true);
             CHECK(dsp.carry == true);
@@ -635,7 +635,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP ALU operations compute correc
             dsp.carry = false;
             dsp.overflow = false;
 
-            dsp.AC.u64 = -1;
+            dsp.AC.u64 = 0xFFFFFFFFFFFF; // -1
             dsp.P.u64 = 1;
             dsp.ALU_AD2();
 
@@ -669,11 +669,11 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP ALU operations compute correc
             dsp.carry = true;
             dsp.overflow = false;
 
-            dsp.AC.u64 = -123;
+            dsp.AC.u64 = 0xFFFFFFFFFF85; // -123
             dsp.P.u64 = 1;
             dsp.ALU_AD2();
 
-            CHECK(dsp.ALU.s64 == -122);
+            CHECK(dsp.ALU.u64 == 0xFFFFFFFFFF86); // -122
             CHECK(dsp.zero == false);
             CHECK(dsp.sign == true);
             CHECK(dsp.carry == false);
@@ -686,11 +686,11 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP ALU operations compute correc
             dsp.carry = false;
             dsp.overflow = false;
 
-            dsp.AC.u64 = -123;
-            dsp.P.u64 = -1;
+            dsp.AC.u64 = 0xFFFFFFFFFF85; // -123
+            dsp.P.u64 = 0xFFFFFFFFFFFF;  // -1
             dsp.ALU_AD2();
 
-            CHECK(dsp.ALU.s64 == -124);
+            CHECK(dsp.ALU.u64 == 0xFFFFFFFFFF84); // -124
             CHECK(dsp.zero == false);
             CHECK(dsp.sign == true);
             CHECK(dsp.carry == true);
@@ -721,7 +721,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP ALU operations compute correc
             dsp.overflow = false;
 
             dsp.AC.u64 = 100;
-            dsp.P.u64 = -1;
+            dsp.P.u64 = 0xFFFFFFFFFFFF; // -1
             dsp.ALU_AD2();
 
             CHECK(dsp.ALU.u64 == 99);
@@ -738,7 +738,7 @@ TEST_CASE_PERSISTENT_FIXTURE(TestSubject, "SCU DSP ALU operations compute correc
             dsp.overflow = false;
 
             dsp.AC.u64 = 0x800000000000;
-            dsp.P.u64 = -1;
+            dsp.P.u64 = 0xFFFFFFFFFFFF; // -1
             dsp.ALU_AD2();
 
             CHECK(dsp.ALU.u64 == 0x7FFFFFFFFFFF);


### PR DESCRIPTION
- remove sint64 s64 member from Reg48 union — single storage type avoids ambiguity after :48 bit-field removal in 36ce9269b
- switch all ALU/P/AC writes from .s64 to .u64
- update tests to use explicit hex literals and check .u64

The :48 bit-field removal in 36ce9269b left Reg48 with both u64 and s64 members but no width constraint.
s64 writes carried incorrect sign extension through bits 48-63, contaminating subsequent ALU operations that read via u64.
Using u64 exclusively confines values to 48 bits via write-side masking.

All ymir-core tests pass again.
Patch by striker, validated by mmkzero

-- marked as critical commit in case of regressions --