### PR TITLE
SH-2/ImGui: Add SH-2 overclocking support

### DIFF
--- a/apps/ymir-sdl3/src/app/events/emu_event_factory.cpp
+++ b/apps/ymir-sdl3/src/app/events/emu_event_factory.cpp
@@ -558,6 +558,10 @@ EmuEvent SetEmulateSH2Cache(bool enable) {
     });
 }
 
+EmuEvent SetSH2OverclockFactor(uint32 factor) {
+    return RunFunction([=](SharedContext &ctx) { ctx.saturn.instance->SetSH2OverclockFactor(factor); });
+}
+
 EmuEvent SetCDBlockLLE(bool enable) {
     return RunFunction([=](SharedContext &ctx) {
         ctx.saturn.instance->configuration.cdblock.useLLE = enable;

--- a/apps/ymir-sdl3/src/app/events/emu_event_factory.hpp
+++ b/apps/ymir-sdl3/src/app/events/emu_event_factory.hpp
@@ -117,6 +117,8 @@ EmuEvent FormatBackupMemory(bool external);
 EmuEvent LoadInternalBackupMemory();
 
 EmuEvent SetEmulateSH2Cache(bool enable);
+EmuEvent SetSH2OverclockFactor(uint32 factor);
+
 EmuEvent SetCDBlockLLE(bool enable);
 
 EmuEvent EnableThreadedVDP1(bool enable);

--- a/apps/ymir-sdl3/src/app/settings.cpp
+++ b/apps/ymir-sdl3/src/app/settings.cpp
@@ -998,6 +998,7 @@ void Settings::ResetToDefaults() {
     system.videoStandard = config::sys::VideoStandard::NTSC;
 
     system.emulateSH2Cache = false;
+    system.sh2OverclockFactor = 100;
 
     system.ipl.overrideImage = false;
     system.ipl.path = "";
@@ -1106,6 +1107,8 @@ void Settings::BindConfiguration(ymir::core::Configuration &config) {
     system.autodetectRegion.Observe(config.system.autodetectRegion);
     system.preferredRegionOrder.Observe([&](auto value) { config.system.preferredRegionOrder = value; });
     system.videoStandard.Observe([&](auto value) { config.system.videoStandard = value; });
+    system.sh2OverclockFactor.ObserveAndNotify(
+        [&](auto value) { m_context.EnqueueEvent(events::emu::SetSH2OverclockFactor(value)); });
 
     system.rtc.mode.Observe([&](auto value) { config.rtc.mode = value; });
     system.rtc.virtHardResetStrategy.Observe([&](auto value) { config.rtc.virtHardResetStrategy = value; });
@@ -1218,6 +1221,7 @@ SettingsLoadResult Settings::Load(const std::filesystem::path &path) {
         Parse(tblSystem, "AutoDetectRegion", system.autodetectRegion);
         Parse(tblSystem, "PreferredRegionOrder", system.preferredRegionOrder);
         Parse(tblSystem, "EmulateSH2Cache", system.emulateSH2Cache);
+        Parse(tblSystem, "SH2OverclockFactor", system.sh2OverclockFactor);
         Parse(tblSystem, "InternalBackupRAMImagePath", system.internalBackupRAMImagePath);
         Parse(tblSystem, "InternalBackupRAMPerGame", system.internalBackupRAMPerGame);
         system.internalBackupRAMImagePath = Absolute(ProfilePath::PersistentState, system.internalBackupRAMImagePath);
@@ -1844,6 +1848,7 @@ SettingsSaveResult Settings::Save() {
             {"AutoDetectRegion", system.autodetectRegion.Get()},
             {"PreferredRegionOrder", ToTOML(system.preferredRegionOrder.Get())},
             {"EmulateSH2Cache", system.emulateSH2Cache},
+            {"SH2OverclockFactor", system.sh2OverclockFactor.Get()},
             {"InternalBackupRAMImagePath", Proximate(ProfilePath::PersistentState, system.internalBackupRAMImagePath).native()},
             {"InternalBackupRAMPerGame", system.internalBackupRAMPerGame},
 

--- a/apps/ymir-sdl3/src/app/settings.hpp
+++ b/apps/ymir-sdl3/src/app/settings.hpp
@@ -183,6 +183,7 @@ struct Settings {
         util::Observable<ymir::core::config::sys::VideoStandard> videoStandard;
 
         bool emulateSH2Cache;
+        util::Observable<uint32> sh2OverclockFactor;
 
         std::filesystem::path internalBackupRAMImagePath;
         bool internalBackupRAMPerGame;

--- a/apps/ymir-sdl3/src/app/ui/views/settings/system_settings_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/settings/system_settings_view.cpp
@@ -132,10 +132,11 @@ void SystemSettingsView::Display() {
     // -----------------------------------------------------------------------------------------------------------------
 
     ImGui::PushFont(m_context.fonts.sansSerif.bold, m_context.fontSizes.large);
-    ImGui::SeparatorText("Accuracy");
+    ImGui::SeparatorText("SH-2");
     ImGui::PopFont();
 
     widgets::settings::system::EmulateSH2Cache(m_context);
+    widgets::settings::system::SH2Overclock(m_context);
 
     // -----------------------------------------------------------------------------------------------------------------
 

--- a/apps/ymir-sdl3/src/app/ui/views/settings/tweaks_settings_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/settings/tweaks_settings_view.cpp
@@ -52,10 +52,13 @@ void TweaksSettingsView::Display() {
         fmt::format_to(inserter, "## Accuracy settings\n");
 
         // -------------------------------------------------------------------------------------------------------------
-        // System
+        // SH-2
 
-        fmt::format_to(inserter, "### System\n");
+        fmt::format_to(inserter, "### SH-2\n");
         fmt::format_to(inserter, "- {}\n", checkbox("Emulate SH-2 cache", settings.system.emulateSH2Cache));
+        if (settings.system.sh2OverclockFactor.Get() != 100) {
+            fmt::format_to(inserter, "- SH-2 cycle rate: {}%\n", settings.system.sh2OverclockFactor.Get());
+        }
 
         // -------------------------------------------------------------------------------------------------------------
         // Video
@@ -175,6 +178,7 @@ void TweaksSettingsView::DisplayAccuracyOptions() {
         m_context.EnqueueEvent(events::emu::SetCDBlockLLE(false));
 
         settings.system.emulateSH2Cache = false;
+        settings.system.sh2OverclockFactor = 100;
 
         settings.audio.interpolation = ymir::core::config::audio::SampleInterpolationMode::Linear;
         settings.audio.stepGranularity = 0;
@@ -198,6 +202,7 @@ void TweaksSettingsView::DisplayAccuracyOptions() {
         m_context.EnqueueEvent(events::emu::SetCDBlockLLE(true));
 
         settings.system.emulateSH2Cache = true;
+        settings.system.sh2OverclockFactor = 100;
 
         settings.audio.interpolation = ymir::core::config::audio::SampleInterpolationMode::Linear;
         settings.audio.stepGranularity = 5;
@@ -224,6 +229,7 @@ void TweaksSettingsView::DisplayAccuracyOptions() {
         m_context.EnqueueEvent(events::emu::SetCDBlockLLE(false));
 
         settings.system.emulateSH2Cache = false;
+        settings.system.sh2OverclockFactor = 100;
 
         settings.audio.interpolation = ymir::core::config::audio::SampleInterpolationMode::Linear;
         settings.audio.stepGranularity = 0;
@@ -240,10 +246,11 @@ void TweaksSettingsView::DisplayAccuracyOptions() {
     // -----------------------------------------------------------------------------------------------------------------
 
     ImGui::PushFont(m_context.fonts.sansSerif.bold, m_context.fontSizes.large);
-    ImGui::SeparatorText("System");
+    ImGui::SeparatorText("SH-2");
     ImGui::PopFont();
 
     widgets::settings::system::EmulateSH2Cache(m_context);
+    widgets::settings::system::SH2Overclock(m_context);
 
     // -----------------------------------------------------------------------------------------------------------------
 

--- a/apps/ymir-sdl3/src/app/ui/widgets/settings_widgets.cpp
+++ b/apps/ymir-sdl3/src/app/ui/widgets/settings_widgets.cpp
@@ -52,6 +52,25 @@ namespace settings::system {
         }
     }
 
+    void SH2Overclock(SharedContext &ctx) {
+        auto &settings = ctx.serviceLocator.GetRequired<Settings>();
+        int factor = settings.system.sh2OverclockFactor.Get();
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("SH-2 cycle rate");
+        widgets::ExplanationTooltip(
+            "WARNING: May break games, desync audio, or cause crashes.\n"
+            "Use with caution!\n\n"
+            "Adjusts the cycle rate of the SH-2 CPUs.\n"
+            "Can improve emulated/guest game performance and reduce slowdowns in CPU-intensive games.",
+            ctx.displayScale);
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(-1.0f);
+        if (settings.MakeDirty(
+                ImGui::SliderInt("##sh2_overclock", &factor, 100, 300, "%d%%", ImGuiSliderFlags_AlwaysClamp))) {
+            settings.system.sh2OverclockFactor = factor;
+        }
+    }
+
 } // namespace settings::system
 
 namespace settings::video {

--- a/apps/ymir-sdl3/src/app/ui/widgets/settings_widgets.hpp
+++ b/apps/ymir-sdl3/src/app/ui/widgets/settings_widgets.hpp
@@ -7,6 +7,7 @@ namespace app::ui::widgets {
 namespace settings::system {
 
     void EmulateSH2Cache(SharedContext &ctx);
+    void SH2Overclock(SharedContext &ctx);
 
 } // namespace settings::system
 

--- a/apps/ymir-sdl3/src/app/ui/windows/system_state_window.cpp
+++ b/apps/ymir-sdl3/src/app/ui/windows/system_state_window.cpp
@@ -154,8 +154,12 @@ void SystemStateWindow::DrawClocks() {
 
         const sys::ClockRatios &clockRatios = m_context.saturn.instance->GetClockRatios();
 
+        const auto &settings = m_context.serviceLocator.GetRequired<Settings>();
+        const double overclockScale = (double)settings.system.sh2OverclockFactor.Get() / 100.0;
         const double masterClock =
-            (double)clockRatios.masterClock * clockRatios.masterClockNum / clockRatios.masterClockDen / 1000000.0;
+            ((double)clockRatios.masterClock * clockRatios.masterClockNum / clockRatios.masterClockDen / 1000000.0) *
+            overclockScale;
+
         ImGui::TableNextRow();
         if (ImGui::TableNextColumn()) {
             ImGui::TextUnformatted("SH-2, SCU and VDPs");

--- a/libs/ymir-core/include/ymir/core/configuration.hpp
+++ b/libs/ymir-core/include/ymir/core/configuration.hpp
@@ -56,6 +56,12 @@ struct Configuration {
         ///
         /// Enabling this option incurs a small performance penalty and purges all SH-2 caches.
         util::Observable<bool> emulateSH2Cache = false;
+
+        /// @brief SH-2 overclock factor as a percentage (100 = 1.0x speed).
+        ///
+        /// Adjusts the cycle rate of the SH-2 CPUs, which may help reduce internal slowdowns
+        /// and lag in CPU-heavy games.
+        util::Observable<uint32> sh2OverclockFactor = 100;
     } system;
 
     /// @brief RTC configuration

--- a/libs/ymir-core/include/ymir/sys/saturn.hpp
+++ b/libs/ymir-core/include/ymir/sys/saturn.hpp
@@ -197,6 +197,12 @@ struct Saturn {
         return m_emulateSH2Caches;
     }
 
+    /// @brief Sets the SH-2 overclock factor.
+    /// @param[in] factor the overclock percentage (100 = normal speed)
+    void SetSH2OverclockFactor(uint32 factor) {
+        configuration.system.sh2OverclockFactor = factor;
+    }
+
     /// @brief Runs the emulator until the end of the current frame using the current settings.
     ///
     /// The implementation of the function depends on the following parameters:
@@ -380,6 +386,10 @@ private:
     /// @brief Updates the SH-2 cache emulation setting and the `RunFrameFn()` pointer.
     /// @param[in] enabled whether to enable SH-2 cache emulation
     void UpdateSH2CacheEmulation(bool enabled);
+
+    /// @brief Updates the SH-2 overclock factor and updates system clock ratios.
+    /// @param[in] factor the new overclock percentage
+    void UpdateSH2OverclockFactor(uint32 factor);
 
     /// @brief Updates the video standard to emulate and adjusts clock ratios across the system's components.
     /// @param[in] videoStandard the new video standard

--- a/libs/ymir-core/include/ymir/sys/system.hpp
+++ b/libs/ymir-core/include/ymir/sys/system.hpp
@@ -13,17 +13,27 @@ namespace ymir::sys {
 struct System {
     core::config::sys::VideoStandard videoStandard = core::config::sys::VideoStandard::NTSC;
     ClockSpeed clockSpeed = ClockSpeed::_320;
+    uint32 sh2OverclockFactor = 100;
 
     const ClockRatios &GetClockRatios() const {
-        const bool clock352 = clockSpeed == ClockSpeed::_352;
-        const bool pal = videoStandard == core::config::sys::VideoStandard::PAL;
-        return kClockRatios[(pal << 1) | (clock352 << 0)];
+        return m_activeClockRatios;
     }
 
     void UpdateClockRatios() {
-        const ClockRatios &clockRatios = GetClockRatios();
+        const bool clock352 = clockSpeed == ClockSpeed::_352;
+        const bool pal = videoStandard == core::config::sys::VideoStandard::PAL;
+        const ClockRatios &baseRatios = kClockRatios[(pal << 1) | (clock352 << 0)];
+
+        m_activeClockRatios = baseRatios;
+        if (sh2OverclockFactor != 100) {
+            m_activeClockRatios.SCSPDen = m_activeClockRatios.SCSPDen * sh2OverclockFactor / 100;
+            m_activeClockRatios.CDBlockDen = m_activeClockRatios.CDBlockDen * sh2OverclockFactor / 100;
+            m_activeClockRatios.SMPCDen = m_activeClockRatios.SMPCDen * sh2OverclockFactor / 100;
+            m_activeClockRatios.RTCDen = m_activeClockRatios.RTCDen * sh2OverclockFactor / 100;
+        }
+
         for (auto &cb : m_clockSpeedChangeCallbacks) {
-            cb(clockRatios);
+            cb(m_activeClockRatios);
         }
     }
 
@@ -58,6 +68,7 @@ struct System {
     }
 
 private:
+    ClockRatios m_activeClockRatios = kClockRatios[0];
     std::vector<CBClockSpeedChange> m_clockSpeedChangeCallbacks;
 };
 

--- a/libs/ymir-core/src/ymir/core/configuration.cpp
+++ b/libs/ymir-core/src/ymir/core/configuration.cpp
@@ -6,6 +6,7 @@ void Configuration::NotifyObservers() {
     system.preferredRegionOrder.Notify();
     system.videoStandard.Notify();
     system.emulateSH2Cache.Notify();
+    system.sh2OverclockFactor.Notify();
 
     rtc.mode.Notify();
 

--- a/libs/ymir-core/src/ymir/hw/vdp/vdp.cpp
+++ b/libs/ymir-core/src/ymir/hw/vdp/vdp.cpp
@@ -11,6 +11,10 @@ VDP::VDP(core::Scheduler &scheduler, core::Configuration &config)
     , m_scheduler(scheduler) {
 
     config.system.videoStandard.Observe([this](VideoStandard videoStandard) { SetVideoStandard(videoStandard); });
+    config.system.sh2OverclockFactor.Observe([this](uint32) {
+        m_state.regs2.TVMDDirty = true;
+        UpdateResolution<false>();
+    });
     config.video.threadedVDP1.Observe([this](bool value) {
         if (auto *renderer = m_renderer->As<VDPRendererType::Software>()) {
             renderer->EnableThreadedVDP1(value);
@@ -676,10 +680,11 @@ void VDP::UpdateResolution() {
                                   : vTimingsNormal[m_state.regs2.TVSTAT.PAL][m_state.regs2.TVMD.VRESOn];
     m_VTimingField = static_cast<uint32>(interlaced) & m_state.regs2.TVSTAT.ODD;
 
-    // Adjust for dot clock
+    // Adjust for dot clock and for SH-2 overclocking
     const uint32 dotClockMult = (m_state.regs2.TVMD.HRESOn & 2) ? 2 : 4;
+    const uint32 overclockFactor = m_config.system.sh2OverclockFactor;
     for (auto &timing : m_HTimings) {
-        timing *= dotClockMult;
+        timing = timing * dotClockMult * overclockFactor / 100;
     }
 
     // Compute cycles available for VBlank erase
@@ -706,7 +711,7 @@ void VDP::UpdateResolution() {
     }};
     static constexpr auto kVPActiveIndex = static_cast<uint32>(VerticalPhase::Active);
     static constexpr auto kVPLastLineIndex = static_cast<uint32>(VerticalPhase::LastLine);
-    m_VBlankEraseCyclesPerLine = kVBEHorzTimings[m_state.regs2.TVMD.HRESOn];
+    m_VBlankEraseCyclesPerLine = kVBEHorzTimings[m_state.regs2.TVMD.HRESOn] * overclockFactor / 100;
     m_VBlankEraseLines = {
         m_VTimings[0][kVPLastLineIndex] - m_VTimings[0][kVPActiveIndex],
         m_VTimings[1][kVPLastLineIndex] - m_VTimings[1][kVPActiveIndex],

--- a/libs/ymir-core/src/ymir/sys/saturn.cpp
+++ b/libs/ymir-core/src/ymir/sys/saturn.cpp
@@ -159,6 +159,7 @@ Saturn::Saturn()
         [&](const std::vector<core::config::sys::Region> &regions) { UpdatePreferredRegionOrder(regions); });
     configuration.system.debugTracing.Observe([&](bool enabled) { UpdateDebugTracing(enabled); });
     configuration.system.emulateSH2Cache.Observe([&](bool enabled) { UpdateSH2CacheEmulation(enabled); });
+    configuration.system.sh2OverclockFactor.Observe([&](uint32 factor) { UpdateSH2OverclockFactor(factor); });
     configuration.system.videoStandard.Observe(
         [&](core::config::sys::VideoStandard videoStandard) { UpdateVideoStandard(videoStandard); });
     configuration.cdblock.useLLE.Observe([&](bool enabled) { SetCDBlockLLE(enabled); });
@@ -810,6 +811,11 @@ void Saturn::UpdateSH2CacheEmulation(bool enabled) {
     }
     m_emulateSH2Caches = enabled;
     UpdateFunctionPointers();
+}
+
+void Saturn::UpdateSH2OverclockFactor(uint32 factor) {
+    m_system.sh2OverclockFactor = factor;
+    m_system.UpdateClockRatios();
 }
 
 void Saturn::UpdateVideoStandard(core::config::sys::VideoStandard videoStandard) {


### PR DESCRIPTION
Adds an SH-2 cycle rate slider (100–300%) under Settings > Tweaks.

Overclocking increases the amount of work the SH-2 CPUs can do, which can improve performance in some games. Other hardware timings are adjusted to keep the rest of the system running at normal speed.

Fixes: #876

One example is Doom, which can see a noticeable performance improvement with higher cycle rates. On my Ryzen 9 9900X, performance in the first level increased from around VDP-1: 12 FPS at the default settings to roughly VDP-1: 20–30 FPS at 300%, depending on what's being being looked at.