### PR TITLE
build(ci): Install glslang and vulkan-headers on FreeBSD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -268,7 +268,7 @@ jobs:
             sudo pkg install -y cmake evdev-proto git gmake libX11 libXcursor libXext \
               libXfixes libXi libXrandr libXrender libXScrnSaver libXtst libglvnd \
               libinotify llvm21 ninja patchelf pkgconf python3 vulkan-loader zip \
-              shaderc
+              glslang shaderc vulkan-headers
 
             if [ ${{ matrix.build-set.library-only}} = 'no' ]; then
               ${{ github.workspace }}/vcpkg/bootstrap-vcpkg.sh

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -136,7 +136,7 @@ Install required packages:
 ```sh
 pkg install cmake evdev-proto git gmake libX11 libXcursor libXext libXfixes libXi \
     libXrandr libXrender libXScrnSaver libXtst libglvnd libinotify llvm19 ninja patchelf \
-    pkgconf python3 vulkan-loader zip shaderc
+    pkgconf python3 vulkan-loader zip glslang shaderc vulkan-headers
 ```
 
 Notes:


### PR DESCRIPTION
Currently CMake's configuration stage can't find `Vulkan`, which can be seen by the following message in the logs:
```
  -- Could NOT find Vulkan (missing: Vulkan_INCLUDE_DIR SPIRV-Tools) (found version "")
```
In order for CMake's `FindVulkan` module to succeed, the following missing dependencies must be installed: `glslang` and `vulkan-headers`