### PR TITLE
fix(app): Remove uses of obsoleted ImGui APIs

### DIFF
--- a/apps/ymir-sdl3/src/app/services/display_service.cpp
+++ b/apps/ymir-sdl3/src/app/services/display_service.cpp
@@ -204,7 +204,6 @@ void DisplayService::LoadFonts() {
             ImFontConfig iconsConfig;
             iconsConfig.MergeMode = true;
             iconsConfig.PixelSnapH = true;
-            iconsConfig.PixelSnapV = true;
             iconsConfig.GlyphMinAdvanceX = 20.0f;
             iconsConfig.GlyphOffset.y = 4.0f;
             font = io.Fonts->AddFontFromMemoryTTF((void *)iconFile.begin(), iconFile.size(), 20.0f, &iconsConfig,

--- a/apps/ymir-sdl3/src/app/ui/views/debug/cdblock_cmd_trace_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/cdblock_cmd_trace_view.cpp
@@ -39,7 +39,7 @@ void CDBlockCommandTraceView::Display() {
         m_tracer.ClearCommands();
     }
     if (settings.cdblock.useLLE) {
-        ImGui::PushTextWrapPos(ImGui::GetContentRegionAvail().x);
+        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
         ImGui::TextColored(m_context.colors.notice,
                            "CD Block LLE is enabled. Commands will be traced to the YGR command trace window instead.");
         ImGui::PopTextWrapPos();

--- a/apps/ymir-sdl3/src/app/ui/views/debug/cdblock_drive_state_trace_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/cdblock_drive_state_trace_view.cpp
@@ -56,7 +56,7 @@ void CDDriveStateTraceView::Display() {
         m_tracer.ClearStateUpdates();
     }
     if (!settings.cdblock.useLLE) {
-        ImGui::PushTextWrapPos(ImGui::GetContentRegionAvail().x);
+        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
         ImGui::TextColored(m_context.colors.notice, "CD Block LLE is disabled. Nothing will be traced here.");
         ImGui::PopTextWrapPos();
     }

--- a/apps/ymir-sdl3/src/app/ui/views/debug/cdblock_ygr_cmd_trace_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/cdblock_ygr_cmd_trace_view.cpp
@@ -41,7 +41,7 @@ void YGRCommandTraceView::Display() {
         m_tracer.ClearCommands();
     }
     if (!settings.cdblock.useLLE) {
-        ImGui::PushTextWrapPos(ImGui::GetContentRegionAvail().x);
+        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
         ImGui::TextColored(
             m_context.colors.notice,
             "CD Block LLE is disabled. Commands will be traced to the CD Block command trace window instead.");

--- a/apps/ymir-sdl3/src/app/ui/views/debug/scsp_slots_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/scsp_slots_view.cpp
@@ -405,16 +405,16 @@ void SCSPSlotsView::Display() {
                                 {centerPos.x, endPos.y},
                                 {endPos.x, centerPos.y},
                             };
-                            drawList->AddPolyline(points, std::size(points), colorValue, ImDrawFlags_RoundCornersAll,
-                                                  thickness);
+                            drawList->AddPolyline(points, std::size(points), colorValue, thickness,
+                                                  ImDrawFlags_RoundCornersAll);
                         } else {
                             const ImVec2 points[] = {
                                 {basePos.x, endPos.y},
                                 {endPos.x, basePos.y},
                                 {endPos.x, endPos.y},
                             };
-                            drawList->AddPolyline(points, std::size(points), colorValue, ImDrawFlags_RoundCornersAll,
-                                                  thickness);
+                            drawList->AddPolyline(points, std::size(points), colorValue, thickness,
+                                                  ImDrawFlags_RoundCornersAll);
                         }
                         break;
                     }
@@ -426,16 +426,16 @@ void SCSPSlotsView::Display() {
                                 {centerPos.x + 0.5f, basePos.y + 0.5f}, {centerPos.x + 0.5f, endPos.y + 0.5f},
                                 {endPos.x + 0.5f, endPos.y + 0.5f},     {endPos.x + 0.5f, centerPos.y + 0.5f},
                             };
-                            drawList->AddPolyline(points, std::size(points), colorValue, ImDrawFlags_RoundCornersAll,
-                                                  thickness);
+                            drawList->AddPolyline(points, std::size(points), colorValue, thickness,
+                                                  ImDrawFlags_RoundCornersAll);
                         } else {
                             const ImVec2 points[] = {
                                 {basePos.x + 0.5f, endPos.y + 0.5f},    {basePos.x + 0.5f, basePos.y + 0.5f},
                                 {centerPos.x + 0.5f, basePos.y + 0.5f}, {centerPos.x + 0.5f, endPos.y + 0.5f},
                                 {endPos.x + 0.5f, endPos.y + 0.5f},
                             };
-                            drawList->AddPolyline(points, std::size(points), colorValue, ImDrawFlags_RoundCornersAll,
-                                                  thickness);
+                            drawList->AddPolyline(points, std::size(points), colorValue, thickness,
+                                                  ImDrawFlags_RoundCornersAll);
                         }
                         break;
                     }
@@ -448,16 +448,16 @@ void SCSPSlotsView::Display() {
                                 {basePos.x + wfSize.x * 0.75f, endPos.y},
                                 {endPos.x, centerPos.y},
                             };
-                            drawList->AddPolyline(points, std::size(points), colorValue, ImDrawFlags_RoundCornersAll,
-                                                  thickness);
+                            drawList->AddPolyline(points, std::size(points), colorValue, thickness,
+                                                  ImDrawFlags_RoundCornersAll);
                         } else {
                             const ImVec2 points[] = {
                                 {basePos.x, endPos.y},
                                 {centerPos.x, basePos.y},
                                 {endPos.x, endPos.y},
                             };
-                            drawList->AddPolyline(points, std::size(points), colorValue, ImDrawFlags_RoundCornersAll,
-                                                  thickness);
+                            drawList->AddPolyline(points, std::size(points), colorValue, thickness,
+                                                  ImDrawFlags_RoundCornersAll);
                         }
                         break;
                     }
@@ -478,8 +478,8 @@ void SCSPSlotsView::Display() {
                                 {basePos.x + wfSize.x * 1.0f, basePos.y + wfSize.y * 0.811f},
                                 {basePos.x + wfSize.x * 1.0f, centerPos.y},
                             };
-                            drawList->AddPolyline(points, std::size(points), colorValue, ImDrawFlags_RoundCornersAll,
-                                                  thickness);
+                            drawList->AddPolyline(points, std::size(points), colorValue, thickness,
+                                                  ImDrawFlags_RoundCornersAll);
                         } else {
                             const ImVec2 points[] = {
                                 {basePos.x + wfSize.x * 0.0f, endPos.y},
@@ -495,8 +495,8 @@ void SCSPSlotsView::Display() {
                                 {basePos.x + wfSize.x * 1.0f, basePos.y + wfSize.y * 0.811f},
                                 {basePos.x + wfSize.x * 1.0f, endPos.y},
                             };
-                            drawList->AddPolyline(points, std::size(points), colorValue, ImDrawFlags_RoundCornersAll,
-                                                  thickness);
+                            drawList->AddPolyline(points, std::size(points), colorValue, thickness,
+                                                  ImDrawFlags_RoundCornersAll);
                         }
                         break;
                     }

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_disassembly_view.cpp
@@ -289,7 +289,7 @@ void SH2DisassemblyView::Display() {
                         auto borderEnd = ImVec2(rectEnd.x - 0.5f, rectEnd.y - 0.5f);
                         drawList->AddRectFilled(rectPos, rectEnd, ImGui::ColorConvertFloat4ToU32(fillColor));
                         drawList->AddRect(borderPos, borderEnd, ImGui::ColorConvertFloat4ToU32(color), 0.0f,
-                                          ImDrawFlags_None, borderThickness);
+                                          borderThickness);
                     }
                 }
 
@@ -297,13 +297,13 @@ void SH2DisassemblyView::Display() {
                 if (address == m_cursor.address && !isCursorHighlighted) {
                     drawList->AddRect(borderPos, borderEnd,
                                       ImGui::ColorConvertFloat4ToU32(m_model.colors.disasm.cursorBgColor), 0.0f,
-                                      ImDrawFlags_None, borderThickness);
+                                      borderThickness);
                 }
 
                 if (lineHovered) {
                     drawList->AddRect(borderPos, borderEnd,
                                       ImGui::ColorConvertFloat4ToU32(m_model.colors.disasm.lineHoverColor), 0.0f,
-                                      ImDrawFlags_None, borderThickness);
+                                      borderThickness);
                 }
             };
 
@@ -401,8 +401,9 @@ void SH2DisassemblyView::Display() {
                         if (visible) {
                             drawList->AddConcavePolyFilled(points, std::size(points), color);
                         } else {
-                            drawList->AddPolyline(points, std::size(points), color, ImDrawFlags_Closed,
-                                                  m_model.style.iconContourThickness * m_context.displayScale);
+                            drawList->AddPolyline(points, std::size(points), color,
+                                                  m_model.style.iconContourThickness * m_context.displayScale,
+                                                  ImDrawFlags_Closed);
                         }
                     }
                 }
@@ -446,8 +447,9 @@ void SH2DisassemblyView::Display() {
                         if (visible) {
                             drawList->AddConcavePolyFilled(points, std::size(points), color);
                         } else {
-                            drawList->AddPolyline(points, std::size(points), color, ImDrawFlags_Closed,
-                                                  m_model.style.iconContourThickness * m_context.displayScale);
+                            drawList->AddPolyline(points, std::size(points), color,
+                                                  m_model.style.iconContourThickness * m_context.displayScale,
+                                                  ImDrawFlags_Closed);
                         }
                     }
                 }
@@ -488,8 +490,7 @@ void SH2DisassemblyView::Display() {
                     ImVec2(startPos.x + disasmCharSize.x * 1.4f, startPos.y + disasmCharSize.y * 0.6f),
                 };
                 const ImVec4 color = valid ? m_model.colors.disasm.delaySlot : m_model.colors.disasm.delaySlotIllegal;
-                drawList->AddPolyline(points, std::size(points), ImGui::ColorConvertFloat4ToU32(color),
-                                      ImDrawFlags_None, 2.0f);
+                drawList->AddPolyline(points, std::size(points), ImGui::ColorConvertFloat4ToU32(color), 2.0f);
                 ImGui::Dummy(ImVec2(0, 0));
             };
 

--- a/apps/ymir-sdl3/src/app/ui/views/debug/sh2_interrupts_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/debug/sh2_interrupts_view.cpp
@@ -162,8 +162,7 @@ void SH2InterruptsView::Display() {
                                            ImVec2(endPos.x + width, endPos.y), endPos};
 
                         ImGui::GetWindowDrawList()->AddPolyline(points, std::size(points),
-                                                                ImColor(style.Colors[ImGuiCol_Separator]),
-                                                                ImDrawFlags_None, thickness);
+                                                                ImColor(style.Colors[ImGuiCol_Separator]), thickness);
                         ImGui::SameLine();
                         ImGui::Dummy(ImVec2(width + paddingX, 0));
                     }

--- a/apps/ymir-sdl3/src/app/ui/views/settings/arcade_racer_config_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/settings/arcade_racer_config_view.cpp
@@ -86,7 +86,7 @@ void ArcadeRacerConfigView::Display(Settings::Input::Port::ArcadeRacer &controll
             const float offset = mapToGraph(value);
             graph.push_back(ImVec2(pos.x + x, pos.y + offset * graphSize.y));
         }
-        drawList->AddPolyline(graph.data(), graph.size(), kGraphLineColor, ImDrawFlags_None, graphLineThickness);
+        drawList->AddPolyline(graph.data(), graph.size(), kGraphLineColor, graphLineThickness);
 
         // Current input value mapped onto the graph, vertical
         const ImVec2 valuePos(pos.x + (currRawValue + 1.0f) * 0.5f * graphSize.x,
@@ -96,8 +96,7 @@ void ArcadeRacerConfigView::Display(Settings::Input::Port::ArcadeRacer &controll
         drawList->AddCircleFilled(valuePos, valuePointRadius, kValueColor);
 
         // Graph border
-        drawList->AddRect(pos, ImVec2(pos.x + graphSize.x, pos.y + graphSize.y), kBorderColor, 0.0f, ImDrawFlags_None,
-                          borderThickness);
+        drawList->AddRect(pos, ImVec2(pos.x + graphSize.x, pos.y + graphSize.y), kBorderColor, 0.0f, borderThickness);
 
         ImGui::Dummy(graphSize);
 
@@ -129,8 +128,7 @@ void ArcadeRacerConfigView::Display(Settings::Input::Port::ArcadeRacer &controll
                           kAdjustedValueColor, valueLineThickness);
 
         // Meter border
-        drawList->AddRect(pos, ImVec2(pos.x + meterSize.x, pos.y + meterSize.y), kBorderColor, 0.0f, ImDrawFlags_None,
-                          borderThickness);
+        drawList->AddRect(pos, ImVec2(pos.x + meterSize.x, pos.y + meterSize.y), kBorderColor, 0.0f, borderThickness);
 
         ImGui::Dummy(meterSize);
     }

--- a/apps/ymir-sdl3/src/app/ui/views/settings/cartridge_settings_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/settings/cartridge_settings_view.cpp
@@ -50,7 +50,7 @@ void CartridgeSettingsView::Display() {
         Settings::Cartridge::Type::ROM,
     };
 
-    ImGui::PushTextWrapPos(ImGui::GetContentRegionMax().x);
+    ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
 
     ImGui::TextUnformatted("Current cartridge: ");
     ImGui::SameLine(0, 0);

--- a/apps/ymir-sdl3/src/app/ui/views/settings/cdblock_settings_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/settings/cdblock_settings_view.cpp
@@ -38,7 +38,7 @@ void CDBlockSettingsView::Display() {
 
     std::filesystem::path cdbRomsPaths = m_context.profile.GetPath(ProfilePath::CDBlockROMImages);
 
-    ImGui::PushTextWrapPos(ImGui::GetContentRegionAvail().x);
+    ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
     ImGui::Text("CD block ROMs in %s", fmt::format("{}", cdbRomsPaths).c_str());
     ImGui::PopTextWrapPos();
 
@@ -191,7 +191,7 @@ void CDBlockSettingsView::Display() {
     if (m_context.cdbRomPath.empty()) {
         ImGui::TextUnformatted("No CD block ROM loaded");
     } else {
-        ImGui::PushTextWrapPos(ImGui::GetContentRegionAvail().x);
+        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
         ImGui::Text("Currently using CD block ROM at %s", fmt::format("{}", m_context.cdbRomPath).c_str());
         ImGui::PopTextWrapPos();
     }

--- a/apps/ymir-sdl3/src/app/ui/views/settings/input_settings_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/settings/input_settings_view.cpp
@@ -19,7 +19,7 @@ InputSettingsView::InputSettingsView(SharedContext &context)
 void InputSettingsView::Display() {
     auto &settings = GetSettings().input;
 
-    ImGui::PushTextWrapPos(ImGui::GetContentRegionAvail().x);
+    ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
 
     if (ImGui::BeginTable("periph_ports", 2, ImGuiTableFlags_SizingStretchSame | ImGuiTableFlags_BordersInnerV)) {
         ImGui::TableNextRow();
@@ -362,8 +362,7 @@ void InputSettingsView::Display() {
                                     kDeadzoneBackgroundColor);
             drawList->AddRectFilled(ImVec2(left, bottom - height * value), ImVec2(right, bottom),
                                     active ? kAxisActiveColor : kAxisAtRestColor);
-            drawList->AddRect(ImVec2(left, top), ImVec2(right, bottom), kBorderColor, 0.0f, ImDrawFlags_None,
-                              borderThickness);
+            drawList->AddRect(ImVec2(left, top), ImVec2(right, bottom), kBorderColor, 0.0f, borderThickness);
 
             // Label and values
             drawText(name, 0, textColor);

--- a/apps/ymir-sdl3/src/app/ui/views/settings/ipl_settings_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/settings/ipl_settings_view.cpp
@@ -54,7 +54,7 @@ void IPLSettingsView::Display() {
 
     std::filesystem::path iplRomsPath = m_context.profile.GetPath(ProfilePath::IPLROMImages);
 
-    ImGui::PushTextWrapPos(ImGui::GetContentRegionAvail().x);
+    ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
     ImGui::Text("IPL ROMs in %s", fmt::format("{}", iplRomsPath).c_str());
     ImGui::PopTextWrapPos();
 
@@ -277,7 +277,7 @@ void IPLSettingsView::Display() {
     if (m_context.iplRomPath.empty()) {
         ImGui::TextUnformatted("No IPL ROM loaded");
     } else {
-        ImGui::PushTextWrapPos(ImGui::GetContentRegionAvail().x);
+        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
         ImGui::Text("Currently using IPL ROM at %s", fmt::format("{}", m_context.iplRomPath).c_str());
         ImGui::PopTextWrapPos();
     }

--- a/apps/ymir-sdl3/src/app/ui/views/settings/system_settings_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/settings/system_settings_view.cpp
@@ -303,7 +303,7 @@ void SystemSettingsView::Display() {
 
     if (settings.internalBackupRAMPerGame) {
         const std::filesystem::path intBupPath = m_context.GetInternalBackupRAMPath();
-        ImGui::PushTextWrapPos(ImGui::GetContentRegionAvail().x);
+        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
         ImGui::Text("Currently using internal backup memory image from %s", fmt::format("{}", intBupPath).c_str());
         ImGui::PopTextWrapPos();
         if (ImGui::Button("Open containing directory##int_bup")) {

--- a/apps/ymir-sdl3/src/app/ui/views/settings/tweaks_settings_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/settings/tweaks_settings_view.cpp
@@ -14,7 +14,7 @@ TweaksSettingsView::TweaksSettingsView(SharedContext &context)
     : SettingsViewBase(context) {}
 
 void TweaksSettingsView::Display() {
-    const float availWidth = ImGui::GetContentRegionAvail().x;
+    const float availWidth = ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x;
 
     ImGui::PushTextWrapPos(availWidth);
     ImGui::TextUnformatted("The options listed in this tab affect emulation accuracy.\n"

--- a/apps/ymir-sdl3/src/app/ui/views/settings/virtua_gun_config_view.cpp
+++ b/apps/ymir-sdl3/src/app/ui/views/settings/virtua_gun_config_view.cpp
@@ -72,7 +72,7 @@ void VirtuaGunConfigView::Display(Settings::Input::Port::VirtuaGun &controllerSe
         widgets::Crosshair(drawList, params, {pos.x + size.x * 0.5f, pos.y + size.y * 0.5f});
         drawList->PopClipRect();
 
-        drawList->AddRect(pos, end, kBorderColor, 0.0f, ImDrawFlags_None, 1.0f * scale);
+        drawList->AddRect(pos, end, kBorderColor, 0.0f, 1.0f * scale);
 
         ImGui::Dummy(size);
 

--- a/apps/ymir-sdl3/src/app/ui/widgets/audio_widgets.cpp
+++ b/apps/ymir-sdl3/src/app/ui/widgets/audio_widgets.cpp
@@ -47,7 +47,7 @@ void Oscilloscope(SharedContext &ctx, std::span<const float> waveform, ImVec2 si
     // TODO: background
     drawList->AddLine(ImVec2(pos.x, pos.y + size.y * 0.5f), ImVec2(pos.x + size.x, pos.y + size.y * 0.5f), 0x7FFFFFFF,
                       centerLineThickness);
-    drawList->AddPolyline(points.data(), points.size(), 0xFFFFFFFF, ImDrawFlags_None, waveThickness);
+    drawList->AddPolyline(points.data(), points.size(), 0xFFFFFFFF, waveThickness);
     // TODO: border
 
     ImGui::Dummy(size);
@@ -86,8 +86,8 @@ void Oscilloscope(SharedContext &ctx, std::span<const StereoSample> waveform, Im
     // TODO: background
     drawList->AddLine(ImVec2(pos.x, pos.y + size.y * 0.5f), ImVec2(pos.x + size.x, pos.y + size.y * 0.5f), 0x45FFFFFF,
                       centerLineThickness);
-    drawList->AddPolyline(pointsL.data(), pointsL.size(), 0xFF7FBFFF, ImDrawFlags_None, waveThickness);
-    drawList->AddPolyline(pointsR.data(), pointsR.size(), 0xFFFFBF7F, ImDrawFlags_None, waveThickness);
+    drawList->AddPolyline(pointsL.data(), pointsL.size(), 0xFF7FBFFF, waveThickness);
+    drawList->AddPolyline(pointsR.data(), pointsR.size(), 0xFFFFBF7F, waveThickness);
     // TODO: border
 
     ImGui::Dummy(size);

--- a/apps/ymir-sdl3/src/app/ui/widgets/input_widgets.cpp
+++ b/apps/ymir-sdl3/src/app/ui/widgets/input_widgets.cpp
@@ -299,7 +299,7 @@ void Crosshair(ImDrawList *drawList, const CrosshairParams &params, ImVec2 pos) 
     }
 
     drawList->AddConvexPolyFilled(points, std::size(points), color);
-    drawList->AddPolyline(points, std::size(points), strokeColor, ImDrawFlags_Closed, strokeThickness);
+    drawList->AddPolyline(points, std::size(points), strokeColor, strokeThickness, ImDrawFlags_Closed);
 }
 
 } // namespace app::ui::widgets

--- a/apps/ymir-sdl3/src/app/ui/widgets/savestate_widgets.cpp
+++ b/apps/ymir-sdl3/src/app/ui/widgets/savestate_widgets.cpp
@@ -120,8 +120,8 @@ void RewindBar(SharedContext &context, float alpha, const RewindBarStyle &style)
 
         // Border
         drawList->AddRect(rectTopLeft, ImVec2(pos.x + avail.x, pos.y + avail.y), borderColor,
-                          style.rounding * context.displayScale, ImDrawFlags_RoundCornersAll,
-                          style.borderThickness * context.displayScale);
+                          style.rounding * context.displayScale, style.borderThickness * context.displayScale,
+                          ImDrawFlags_RoundCornersAll);
     }
     ImGui::End();
 }

--- a/apps/ymir-sdl3/src/app/ui/windows/about_window.cpp
+++ b/apps/ymir-sdl3/src/app/ui/windows/about_window.cpp
@@ -261,7 +261,7 @@ void AboutWindow::DrawContents() {
 }
 
 void AboutWindow::DrawAboutTab() {
-    ImGui::PushTextWrapPos(ImGui::GetWindowContentRegionMax().x);
+    ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
 
     const auto &midiService = m_context.serviceLocator.GetRequired<services::MIDIService>();
     const auto &graphicsService = m_context.serviceLocator.GetRequired<services::GraphicsService>();
@@ -460,7 +460,7 @@ void AboutWindow::DrawDependenciesTab() {
 }
 
 void AboutWindow::DrawAcknowledgementsTab() {
-    ImGui::PushTextWrapPos(ImGui::GetWindowContentRegionMax().x);
+    ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
 
     ImGui::PushFont(m_context.fonts.sansSerif.bold, m_context.fontSizes.large);
     ImGui::TextUnformatted("Ymir was made possible by");

--- a/apps/ymir-sdl3/src/app/ui/windows/about_window.cpp
+++ b/apps/ymir-sdl3/src/app/ui/windows/about_window.cpp
@@ -227,7 +227,7 @@ void AboutWindow::PrepareWindow() {
                             ImVec2(0.5f, 0.5f));
     ImGui::SetNextWindowSize(ImVec2(660 * m_context.displayScale, 800 * m_context.displayScale),
                              ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSizeConstraints(ImVec2(400 * m_context.displayScale, 240 * m_context.displayScale),
+    ImGui::SetNextWindowSizeConstraints(ImVec2(480 * m_context.displayScale, 320 * m_context.displayScale),
                                         ImVec2(1000 * m_context.displayScale, 900 * m_context.displayScale));
 }
 
@@ -276,8 +276,7 @@ void AboutWindow::DrawAboutTab() {
     ImGui::TextUnformatted("Version " Ymir_VERSION);
     ImGui::PopFont();
 #if Ymir_DEV_BUILD
-    ImGui::SameLine();
-    ImGui::PushFont(m_context.fonts.sansSerif.regular, m_context.fontSizes.xlarge);
+    ImGui::PushFont(m_context.fonts.sansSerif.regular, m_context.fontSizes.large);
     ImGui::TextUnformatted("(development build)");
     ImGui::PopFont();
 #endif

--- a/apps/ymir-sdl3/src/app/ui/windows/system_state_window.cpp
+++ b/apps/ymir-sdl3/src/app/ui/windows/system_state_window.cpp
@@ -555,7 +555,7 @@ void SystemStateWindow::DrawCDDrive() {
 }
 
 void SystemStateWindow::DrawDiscImage() {
-    ImGui::PushTextWrapPos(ImGui::GetContentRegionAvail().x);
+    ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
     if (m_context.state.loadedDiscImagePath.empty() && m_context.state.loadedDiscDrivePath.empty()) {
         ImGui::TextUnformatted("No disc loaded");
     } else {


### PR DESCRIPTION
Every once in a while we should define IMGUI_DISABLE_OBSOLETE_FUNCTIONS so we can find and drop old ImGui APIs.