### PR TITLE
fix(app): Fix double scaling the UI on macOS

### DIFF
--- a/apps/ymir-sdl3/src/app/app.cpp
+++ b/apps/ymir-sdl3/src/app/app.cpp
@@ -600,7 +600,7 @@ void App::RunEmulator() {
 
     // RescaleUI also loads the style and fonts
     bool rescaleUIPending = false;
-    m_displayService.RescaleUI(SDL_GetDisplayContentScale(SDL_GetPrimaryDisplay()));
+    m_displayService.RescaleUI();
     {
         auto &guiSettings = settings.gui;
 
@@ -750,6 +750,7 @@ void App::RunEmulator() {
         m_saveStateService.SaveDebuggerState();
     }};
     util::os::ConfigureWindowDecorations(screen.window);
+    m_displayService.RescaleUI();
 
     settings.video.fullScreen.Observe([&](bool fullScreen) {
         devlog::info<grp::base>("{} full screen mode", (fullScreen ? "Entering" : "Leaving"));
@@ -1630,11 +1631,9 @@ void App::RunEmulator() {
 
             case SDL_EVENT_WINDOW_LEAVE_FULLSCREEN: util::os::ConfigureWindowDecorations(screen.window); break;
 
-            case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED: [[fallthrough]];
             case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED:
                 if (!settings.gui.overrideUIScale) {
-                    const float windowScale = SDL_GetWindowDisplayScale(screen.window);
-                    m_displayService.RescaleUI(windowScale);
+                    m_displayService.RescaleUI();
                     m_displayService.PersistWindowGeometry();
                 }
                 break;
@@ -1678,8 +1677,7 @@ void App::RunEmulator() {
         }
         if (rescaleUIPending) {
             rescaleUIPending = false;
-            const float windowScale = SDL_GetWindowDisplayScale(screen.window);
-            m_displayService.RescaleUI(windowScale);
+            m_displayService.RescaleUI();
         }
 
         // Process all axis changes

--- a/apps/ymir-sdl3/src/app/services/display_service.cpp
+++ b/apps/ymir-sdl3/src/app/services/display_service.cpp
@@ -29,8 +29,25 @@ DisplayService::DisplayService(SharedContext &context, Settings &settings)
     : m_context(context)
     , m_settings(settings) {}
 
-void DisplayService::RescaleUI(float displayScale) {
+namespace {
+
+    float LogicalUIScale(SDL_Window *window) {
+        // ImGui handles Retina via DisplayFramebufferScale
+#if defined(__APPLE__)
+        (void)window;
+        return 1.0f;
+#else
+        const SDL_DisplayID display = window != nullptr ? SDL_GetDisplayForWindow(window) : SDL_GetPrimaryDisplay();
+        const float contentScale = SDL_GetDisplayContentScale(display);
+        return contentScale > 0.0f ? contentScale : 1.0f;
+#endif
+    }
+
+} // namespace
+
+void DisplayService::RescaleUI() {
     const auto &settings = m_settings;
+    float displayScale = LogicalUIScale(m_context.screen.window);
     if (settings.gui.overrideUIScale) {
         displayScale = settings.gui.uiScale;
     }

--- a/apps/ymir-sdl3/src/app/services/display_service.hpp
+++ b/apps/ymir-sdl3/src/app/services/display_service.hpp
@@ -16,9 +16,8 @@ public:
     DisplayService(const DisplayService &) = delete;
     DisplayService &operator=(const DisplayService &) = delete;
 
-    /// @brief Rescales the UI based on system or custom DPI scale.
-    /// @param[in] displayScale New scale factor.
-    void RescaleUI(float displayScale);
+    /// @brief Rescales the UI from the system or a custom override.
+    void RescaleUI();
 
     /// @brief Reloads the ImGui colors and style properties.
     /// @param[in] displayScale UI scale factor to adjust spacing/padding.


### PR DESCRIPTION
We were applying the window display scale on top of what ImGui already does for Retina, so the UI ended up twice as big on macOS.