### PR TITLE
fix(build): Add LIBICONV_PLUG definition for FreeBSD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -268,7 +268,7 @@ jobs:
             sudo pkg install -y cmake evdev-proto git gmake libX11 libXcursor libXext \
               libXfixes libXi libXrandr libXrender libXScrnSaver libXtst libglvnd \
               libinotify llvm21 ninja patchelf pkgconf python3 vulkan-loader zip \
-              glslang shaderc vulkan-headers converters/libiconv
+              glslang shaderc vulkan-headers
 
             if [ ${{ matrix.build-set.library-only}} = 'no' ]; then
               ${{ github.workspace }}/vcpkg/bootstrap-vcpkg.sh

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -137,7 +137,7 @@ Install required packages:
 ```sh
 pkg install cmake evdev-proto git gmake libX11 libXcursor libXext libXfixes libXi \
     libXrandr libXrender libXScrnSaver libXtst libglvnd libinotify llvm19 ninja patchelf \
-    pkgconf python3 vulkan-loader zip glslang shaderc vulkan-headers converters/libiconv
+    pkgconf python3 vulkan-loader zip glslang shaderc vulkan-headers
 ```
 
 Notes:

--- a/libs/ymir-core/CMakeLists.txt
+++ b/libs/ymir-core/CMakeLists.txt
@@ -465,6 +465,10 @@ elseif (UNIX) # Linux and FreeBSD
     target_link_libraries(ymir-core PUBLIC
         Iconv::Iconv
     )
+    if (CMAKE_SYSTEM_NAME MATCHES FreeBSD)
+        # Prevent third-party package libiconv from interfering with iconv from libc.
+        target_compile_definitions(ymir-core PUBLIC "LIBICONV_PLUG")
+    endif ()
 endif ()
 
 if (Vulkan_FOUND)


### PR DESCRIPTION
Although FreeBSD provides an `iconv` implementation in its libc, the presence of the third-party package `libiconv` interferes with the build process and ultimatly results in "undefined symbol" linker errors, e.g. for `libiconv_open`.

This is caused by `libiconv`'s `/usr/local/include/iconv.h`, which the build process prioritizes over libc's `/usr/include/iconv.h`. It prepends the symbols with the "lib" prefix, e.g. `iconv_open` -> `libiconv_open`, which results in these linker errors.

CMake's `FindIconv` module doesn't help here, because it prioritizes libc's `iconv` implementation if provided by the platform, therefore it doesn't set up `libiconv` for linking.

`libiconv` can be present in the build environment as a transitive dependency of some direct dependency. In the case of the FreeBSD VM image used in the CI, `libiconv` is actually preinstalled in the image.

This is a known error path in the FreeBSD environment, which is why there exists workarounds for this in the FreeBSD ports framework and in the `libiconv` port itself: the `libiconv` port is patched to honor the `LIBICONV_PLUG` compile definition, which prevents prefixing the symbols with "lib".

Adding the `LIBICONV_PLUG` definition allows the linker to find the expected symbols in libc.