### PR TITLE
fix(app): Clean up emulator thread shutdown and audio sync

### DIFF
--- a/apps/ymir-sdl3/src/app/app.cpp
+++ b/apps/ymir-sdl3/src/app/app.cpp
@@ -1248,20 +1248,8 @@ void App::RunEmulator() {
     m_mouseHideTime = t;
 
     // Start emulator thread
-    m_emuThread = std::thread([&] { EmulatorThread(); });
-    ScopeGuard sgStopEmuThread{[&] {
-        // TODO: fix this hacky mess
-        // HACK: unpause, unsilence audio system and set frame request signal in order to unlock the emulator thread if
-        // it is waiting for free space in the audio buffer due to being paused
-        m_emuProcessEvent.Set();
-        m_context.audioSystem.SetSilent(false);
-        screen.frameRequestEvent.Set();
-        m_context.EnqueueEvent(events::emu::SetPaused(false));
-        m_context.EnqueueEvent(events::emu::Shutdown());
-        if (m_emuThread.joinable()) {
-            m_emuThread.join();
-        }
-    }};
+    StartEmulatorThread();
+    ScopeGuard sgStopEmuThread{[this] { StopEmulatorThread(); }};
 
     // Start screenshot processor thread
     m_screenshotService.Start(m_context);
@@ -3338,6 +3326,23 @@ void App::RunEmulator() {
 end_loop:; // the semicolon is not a typo!
 
     // Everything is cleaned up automatically by ScopeGuards
+}
+
+void App::StartEmulatorThread() {
+    m_emuThread = std::thread([this] { EmulatorThread(); });
+}
+
+void App::StopEmulatorThread() {
+    if (!m_emuThread.joinable()) {
+        return;
+    }
+
+    m_emuProcessEvent.Set();
+    m_context.screen.frameRequestEvent.Set();
+    m_context.audioSystem.SetSilent(true);
+    m_context.EnqueueEvent(events::emu::Shutdown());
+
+    m_emuThread.join();
 }
 
 void App::EmulatorThread() {

--- a/apps/ymir-sdl3/src/app/app.hpp
+++ b/apps/ymir-sdl3/src/app/app.hpp
@@ -60,6 +60,8 @@ private:
 
     void RunEmulator();
 
+    void StartEmulatorThread();
+    void StopEmulatorThread();
     void EmulatorThread();
 
     void EnableRewindBuffer(bool enable);

--- a/apps/ymir-sdl3/src/app/audio_system.cpp
+++ b/apps/ymir-sdl3/src/app/audio_system.cpp
@@ -76,16 +76,30 @@ bool AudioSystem::GetAudioStreamFormat(int *sampleRate, SDL_AudioFormat *format,
 void AudioSystem::ReceiveSample(sint16 left, sint16 right) {
     // If we're doing audio sync, wait until the buffer is no longer full.
     // Otherwise, simply overrun the buffer.
-    if (m_sync && !m_silent) {
+    while (m_sync && !m_silent) {
+        const uint32 readPos = m_readPos.load(std::memory_order_acquire);
+        const uint32 writePos = m_writePos.load(std::memory_order_relaxed);
+        const uint32 count = (writePos >= readPos) ? (writePos - readPos) : (m_buffer.size() - (readPos - writePos));
+        if (count < m_buffer.size() - 1) {
+            break;
+        }
+
+        m_bufferNotFullEvent.Reset();
+
+        const uint32 recheckReadPos = m_readPos.load(std::memory_order_acquire);
+        const uint32 recheckCount = (writePos >= recheckReadPos) ? (writePos - recheckReadPos)
+                                                                 : (m_buffer.size() - (recheckReadPos - writePos));
+        if (recheckCount < m_buffer.size() - 1) {
+            m_bufferNotFullEvent.Set();
+            break;
+        }
+
         m_bufferNotFullEvent.Wait();
     }
 
-    m_buffer[m_writePos] = {left, right};
-
-    m_writePos = (m_writePos + 1) % m_buffer.size();
-    if (m_writePos == m_readPos) {
-        m_bufferNotFullEvent.Reset();
-    }
+    const uint32 writePos = m_writePos.load(std::memory_order_relaxed);
+    m_buffer[writePos] = {left, right};
+    m_writePos.store((writePos + 1) % m_buffer.size(), std::memory_order_release);
 }
 
 void AudioSystem::UpdateGain() {
@@ -93,20 +107,39 @@ void AudioSystem::UpdateGain() {
 }
 
 void AudioSystem::ProcessAudioCallback(SDL_AudioStream *stream, int additional_amount, int total_amount) {
-    int sampleCount = additional_amount / sizeof(Sample);
+    const int sampleCount = additional_amount / sizeof(Sample);
     if (m_silent) {
         const sint16 zero = 0;
         for (int i = 0; i < sampleCount; i++) {
             SDL_PutAudioStreamData(stream, &zero, sizeof(zero));
         }
     } else {
-        const uint32 readPos = m_readPos.load(std::memory_order_acquire);
-        int len1 = std::min<int>(sampleCount, m_buffer.size() - readPos);
-        int len2 = std::min<int>(sampleCount - len1, readPos);
-        SDL_PutAudioStreamData(stream, &m_buffer[readPos], len1 * sizeof(Sample));
-        SDL_PutAudioStreamData(stream, &m_buffer[0], len2 * sizeof(Sample));
+        const uint32 readPos = m_readPos.load(std::memory_order_relaxed);
+        const uint32 writePos = m_writePos.load(std::memory_order_acquire);
+        const uint32 available =
+            (writePos >= readPos) ? (writePos - readPos) : (m_buffer.size() - (readPos - writePos));
 
-        m_readPos.store((readPos + len1 + len2) % m_buffer.size(), std::memory_order_release);
+        const int toRead = std::min<int>(sampleCount, static_cast<int>(available));
+        const int len1 = std::min<int>(toRead, static_cast<int>(m_buffer.size() - readPos));
+        const int len2 = toRead - len1;
+
+        if (len1 > 0) {
+            SDL_PutAudioStreamData(stream, &m_buffer[readPos], len1 * sizeof(Sample));
+        }
+        if (len2 > 0) {
+            SDL_PutAudioStreamData(stream, &m_buffer[0], len2 * sizeof(Sample));
+        }
+
+        // Fill buffer underrun with silence
+        const int remaining = sampleCount - toRead;
+        if (remaining > 0) {
+            const sint16 zero = 0;
+            for (int i = 0; i < remaining; i++) {
+                SDL_PutAudioStreamData(stream, &zero, sizeof(zero));
+            }
+        }
+
+        m_readPos.store((readPos + toRead) % m_buffer.size(), std::memory_order_release);
         m_bufferNotFullEvent.Set();
     }
 }

--- a/apps/ymir-sdl3/src/app/audio_system.hpp
+++ b/apps/ymir-sdl3/src/app/audio_system.hpp
@@ -30,7 +30,7 @@ public:
     void ReceiveSample(sint16 left, sint16 right);
 
     void Snapshot(std::span<Sample, 2048> out) const {
-        const uint32 readPos = m_readPos;
+        const uint32 readPos = m_readPos.load(std::memory_order_relaxed);
         std::copy(m_buffer.begin() + readPos, m_buffer.end(), out.begin());
         std::copy(m_buffer.begin(), m_buffer.begin() + readPos, out.begin() + out.size() - readPos);
     }
@@ -55,6 +55,9 @@ public:
 
     void SetSync(bool sync) {
         m_sync = sync;
+        if (!sync) {
+            m_bufferNotFullEvent.Set();
+        }
     }
 
     bool IsSync() const {
@@ -73,11 +76,9 @@ public:
     }
 
     uint32 GetBufferCount() const {
-        uint32 total = m_writePos - m_readPos + m_buffer.size();
-        if (total > m_buffer.size()) {
-            total -= m_buffer.size();
-        }
-        return total;
+        const uint32 readPos = m_readPos.load(std::memory_order_relaxed);
+        const uint32 writePos = m_writePos.load(std::memory_order_relaxed);
+        return (writePos >= readPos) ? (writePos - readPos) : (m_buffer.size() - (readPos - writePos));
     }
 
     uint32 GetBufferCapacity() const {
@@ -90,11 +91,11 @@ private:
 
     std::array<Sample, 2048> m_buffer{};
     std::atomic_uint32_t m_readPos = 0;
-    uint32 m_writePos = 0;
+    std::atomic_uint32_t m_writePos = 0;
     util::Event m_bufferNotFullEvent{true};
 
-    bool m_sync = true;
-    bool m_silent = false;
+    std::atomic_bool m_sync = true;
+    std::atomic_bool m_silent = false;
 
     float m_gain = 0.8f;
     bool m_mute = false;


### PR DESCRIPTION
Removes the hacky shutdown scope guard in `App::RunEmulator` and fixes audio sync races that caused deadlocks on exit/pause.